### PR TITLE
Require ruby-duration 3.2.3+ to avoid issues:

### DIFF
--- a/moonshot.gemspec
+++ b/moonshot.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency('highline', '~> 1.7.2')
   s.add_dependency('interactive-logger', '~> 0.1.1')
   s.add_dependency('rotp', '~> 2.1.1')
-  s.add_dependency('ruby-duration')
+  s.add_dependency('ruby-duration', '~> 3.2.3')
   s.add_dependency('thor', '~> 0.19.1')
   s.add_dependency('semantic')
   s.add_dependency('vandamme')


### PR DESCRIPTION
- < 3.2.2 includes in activesupport json which breaks time formatting in JSON objects.
- 3.2.2 doesn't have a default locale, leading to uncaught i18n exception.