### PR TITLE
Minify stack template JSON to save bytes

### DIFF
--- a/lib/moonshot/stack_template.rb
+++ b/lib/moonshot/stack_template.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Moonshot
   # A StackTemplate loads the JSON template from disk and stores information
   # about it.
@@ -18,7 +20,9 @@ module Moonshot
         raise
       end
 
-      @body = File.read(filename)
+      # The maximum TemplateBody length is 51,200 bytes, so we remove
+      # formatting white space.
+      @body = JSON.parse(File.read(filename)).to_json
     end
 
     def parameters


### PR DESCRIPTION
Per the [AWS API reference](http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_ValidateTemplate.html) the maximum length for TemplateBody is 51,200 bytes.  If a user has a very large base template then formatting with white space takes up precious bytes.  A user of moonshot should not have to compromise the readability of their template or code their own JSON minifier.