### PR TITLE
Make the Deployment Configuration Name value configurable.

### DIFF
--- a/docs/mechanisms/deployment.md
+++ b/docs/mechanisms/deployment.md
@@ -7,7 +7,6 @@ The CodeDeploy DeploymentMechanism will create a CodeDeploy Application and Depl
 Assumptions made by the CodeDeploy mechanism:
 
 - You are using an S3Bucket ArtifactRepository.
-- You want to deploy using the OneAtATime method.
 - Your build artifact contains an appspec.yml file.
 
 Sample Usage
@@ -18,7 +17,7 @@ require 'moonshot'
 
 # Set up Moonshot tooling for our environment.
 class MoonshotSampleApp < Moonshot::CLI
-  self.deployment_mechanism = CodeDeploy.new(asg: 'AutoScalingGroup', role: 'CodeDeployRole', app_name: 'my_app_name')
+  self.deployment_mechanism = CodeDeploy.new(asg: 'AutoScalingGroup', role: 'CodeDeployRole', app_name: 'my_app_name', config_name: 'CodeDeployDefault.OneAtATime')
 ...
 ```
 Parameters
@@ -36,6 +35,11 @@ IAM role with AWSCodeDeployRole policy. CodeDeployRole is considered as default 
 
 The name of the CodeDeploy Application and Deployment Group. By default, this is the same as the stack name, and probably what you want. If you have multiple deployments in a single Stack, they must have unique names.
 
+### config_name | string
+
+The name of the Deplloyment Configuration. CodeDeployDefault.OneAtATime is the default if its not specified.
+
 For more information about CodeDeploy, see the [AWS Documentation][1].
+
 
 [1]: http://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html

--- a/lib/moonshot/deployment_mechanism/code_deploy.rb
+++ b/lib/moonshot/deployment_mechanism/code_deploy.rb
@@ -23,10 +23,18 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
   #   The name of the CodeDeploy Application and Deployment Group. By default,
   #   this is the same as the stack name, and probably what you want. If you
   #   have multiple deployments in a single Stack, they must have unique names.
-  def initialize(asg:, role: 'CodeDeployRole', app_name: nil)
+  # @param config_name [String]
+  #   Name of the Deployment Config to use for COdeDeploy,  By default we use
+  #   CodeDeployDefault.OneAtATime.
+  def initialize(
+      asg:,
+      role: 'CodeDeployRole',
+      app_name: nil,
+      config_name: 'CodeDeployDefault.OneAtATime')
     @asg_logical_id = asg
     @app_name = app_name
     @codedeploy_role = role
+    @codedeploy_config = config_name
   end
 
   def post_create_hook
@@ -58,7 +66,7 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
         application_name: app_name,
         deployment_group_name: app_name,
         revision: revision_for_artifact_repo(artifact_repo, version_name),
-        deployment_config_name: 'CodeDeployDefault.OneAtATime',
+        deployment_config_name: @codedeploy_config,
         description: "Deploying version #{version_name}"
       )
       deployment_id = res.deployment_id


### PR DESCRIPTION
Addes a new, optional parameter for the Deployment Configuration Name.  Defaults to "CodeDeployDefault.OneAtATime" which was originally hard coded.