### PR TITLE
Multiple ASGs in deployment group

### DIFF
--- a/docs/mechanisms/deployment.md
+++ b/docs/mechanisms/deployment.md
@@ -7,7 +7,6 @@ The CodeDeploy DeploymentMechanism will create a CodeDeploy Application and Depl
 Assumptions made by the CodeDeploy mechanism:
 
 - You are using an S3Bucket ArtifactRepository.
-- You want to deploy using the OneAtATime method.
 - Your build artifact contains an appspec.yml file.
 
 Sample Usage
@@ -18,7 +17,7 @@ require 'moonshot'
 
 # Set up Moonshot tooling for our environment.
 class MoonshotSampleApp < Moonshot::CLI
-  self.deployment_mechanism = CodeDeploy.new(asg: 'AutoScalingGroup', role: 'CodeDeployRole', app_name: 'my_app_name')
+  self.deployment_mechanism = CodeDeploy.new(asg: 'AutoScalingGroup', role: 'CodeDeployRole', app_name: 'my_app_name', config_name: 'CodeDeployDefault.OneAtATime')
 ...
 ```
 Parameters
@@ -36,6 +35,11 @@ IAM role with AWSCodeDeployRole policy. CodeDeployRole is considered as default 
 
 The name of the CodeDeploy Application and Deployment Group. By default, this is the same as the stack name, and probably what you want. If you have multiple deployments in a single Stack, they must have unique names.
 
+### config_name | string
+
+The name of the Deplloyment Configuration. CodeDeployDefault.OneAtATime is the default if its not specified.
+
 For more information about CodeDeploy, see the [AWS Documentation][1].
+
 
 [1]: http://docs.aws.amazon.com/codedeploy/latest/userguide/welcome.html

--- a/docs/mechanisms/deployment.md
+++ b/docs/mechanisms/deployment.md
@@ -22,9 +22,9 @@ class MoonshotSampleApp < Moonshot::CLI
 ```
 Parameters
 
-### asg | string
+### asg | string,array
 
-The logical name of the AutoScalingGroup to create and manage a Deployment
+The logical name of one or more Auto Scaling Groups to create and manage a Deployment
 Group for in CodeDeploy.
 
 ### role | string

--- a/lib/moonshot/deployment_mechanism/code_deploy.rb
+++ b/lib/moonshot/deployment_mechanism/code_deploy.rb
@@ -229,7 +229,7 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
   end
 
   def wait_for_asg_capacity
-    ilog.start 'Waiting for AutoScaling Group to reach capacity...' do |s|
+    ilog.start 'Waiting for AutoScaling Group(s) to reach capacity...' do |s|
       loop do
         asgs_at_capacity = 0
         asgs = load_auto_scaling_groups

--- a/lib/moonshot/deployment_mechanism/code_deploy.rb
+++ b/lib/moonshot/deployment_mechanism/code_deploy.rb
@@ -23,10 +23,18 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
   #   The name of the CodeDeploy Application and Deployment Group. By default,
   #   this is the same as the stack name, and probably what you want. If you
   #   have multiple deployments in a single Stack, they must have unique names.
-  def initialize(asg:, role: 'CodeDeployRole', app_name: nil)
+  # @param config_name [String]
+  #   Name of the Deployment Config to use for COdeDeploy,  By default we use
+  #   CodeDeployDefault.OneAtATime.
+  def initialize(
+      asg:,
+      role: 'CodeDeployRole',
+      app_name: nil,
+      config_name: 'CodeDeployDefault.OneAtATime')
     @asg_logical_id = asg
     @app_name = app_name
     @codedeploy_role = role
+    @codedeploy_config = config_name
   end
 
   def post_create_hook
@@ -58,7 +66,7 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
         application_name: app_name,
         deployment_group_name: app_name,
         revision: revision_for_artifact_repo(artifact_repo, version_name),
-        deployment_config_name: 'CodeDeployDefault.OneAtATime',
+        deployment_config_name: @codedeploy_config,
         description: "Deploying version #{version_name}"
       )
       deployment_id = res.deployment_id

--- a/lib/moonshot/deployment_mechanism/code_deploy.rb
+++ b/lib/moonshot/deployment_mechanism/code_deploy.rb
@@ -13,7 +13,7 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
   include Moonshot::CredsHelper
   include Moonshot::DoctorHelper
 
-  # @param asg [String]
+  # @param asg [Array, String]
   #   The logical name of the AutoScalingGroup to create and manage a Deployment
   #   Group for in CodeDeploy.
   # @param role [String]
@@ -24,14 +24,14 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
   #   this is the same as the stack name, and probably what you want. If you
   #   have multiple deployments in a single Stack, they must have unique names.
   # @param config_name [String]
-  #   Name of the Deployment Config to use for COdeDeploy,  By default we use
+  #   Name of the Deployment Config to use for CodeDeploy,  By default we use
   #   CodeDeployDefault.OneAtATime.
   def initialize(
-      asg:,
+      asg: [],
       role: 'CodeDeployRole',
       app_name: nil,
       config_name: 'CodeDeployDefault.OneAtATime')
-    @asg_logical_id = asg
+    @asg_logical_ids = asg.is_a?(Array) ? asg : [asg]
     @app_name = app_name
     @codedeploy_role = role
     @codedeploy_config = config_name
@@ -139,27 +139,35 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
     end
   end
 
-  def auto_scaling_group
-    @auto_scaling_group ||= load_auto_scaling_group
+  def auto_scaling_groups
+    @auto_scaling_groups ||= load_auto_scaling_groups
   end
 
-  def load_auto_scaling_group
-    asg_name = stack.physical_id_for(@asg_logical_id)
-    unless asg_name
-      raise Thor::Error, "Could not find #{@asg_logical_id} resource in Stack."
-    end
+  def load_auto_scaling_groups
+    autoscaling_groups = []
+    @asg_logical_ids.each do |asg_logical_id|
+      asg_name = stack.physical_id_for(asg_logical_id)
+      unless asg_name
+        raise Thor::Error, "Could not find #{asg_logical_id} resource in Stack."
+      end
 
-    groups = as_client.describe_auto_scaling_groups(
-      auto_scaling_group_names: [asg_name])
-    if groups.auto_scaling_groups.empty?
-      raise Thor::Error, "Could not find ASG #{asg_name}."
-    end
+      groups = as_client.describe_auto_scaling_groups(
+        auto_scaling_group_names: [asg_name])
+      if groups.auto_scaling_groups.empty?
+        raise Thor::Error, "Could not find ASG #{asg_name}."
+      end
 
-    groups.auto_scaling_groups.first
+      autoscaling_groups.push(groups.auto_scaling_groups.first)
+    end
+    autoscaling_groups
   end
 
-  def asg_name
-    auto_scaling_group.auto_scaling_group_name
+  def asg_names
+    names = []
+    auto_scaling_groups.each do |auto_scaling_group|
+      names.push(auto_scaling_group.auto_scaling_group_name)
+    end
+    names
   end
 
   def application_exists?
@@ -186,9 +194,15 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
 
   def deployment_group_ok?
     return false unless deployment_group_exists?
-    asg = deployment_group.auto_scaling_groups.first
-    return false unless asg
-    asg.name == auto_scaling_group.auto_scaling_group_name
+    asgs = deployment_group.auto_scaling_groups
+    return false unless asgs
+    return false unless asgs.count == auto_scaling_groups.count
+    asgs.each do |asg|
+      if (auto_scaling_groups.find_index { |a| a.auto_scaling_group_name == asg.name }).nil?
+        return false
+      end
+    end
+    true
   end
 
   def role
@@ -211,20 +225,26 @@ class Moonshot::DeploymentMechanism::CodeDeploy # rubocop:disable ClassLength
       application_name: app_name,
       deployment_group_name: app_name,
       service_role_arn: role.arn,
-      auto_scaling_groups: [asg_name])
+      auto_scaling_groups: asg_names)
   end
 
   def wait_for_asg_capacity
     ilog.start 'Waiting for AutoScaling Group to reach capacity...' do |s|
       loop do
-        asg = load_auto_scaling_group
-        count = asg.instances.count { |i| i.lifecycle_state == 'InService' }
-        break if asg.desired_capacity == count
-        s.continue "DesiredCapacity is #{asg.desired_capacity}, currently #{count} instance(s) are InService." # rubocop:disable LineLength
+        asgs_at_capacity = 0
+        asgs = load_auto_scaling_groups
+        asgs.each do |asg|
+          count = asg.instances.count { |i| i.lifecycle_state == 'InService' }
+          if asg.desired_capacity == count
+            asgs_at_capacity += 1
+            s.continue "#{asg.auto_scaling_group_name} DesiredCapacity is #{asg.desired_capacity}, currently #{count} instance(s) are InService." # rubocop:disable LineLength
+          end
+        end
+        break if asgs.count == asgs_at_capacity
         sleep 5
       end
 
-      s.success 'AutoScaling Group up to capacity!'
+      s.success 'AutoScaling Group(s) up to capacity!'
     end
   end
 


### PR DESCRIPTION
This PR adds the ability for Moonshot to create and validate deployment groups containing multiple ASGs per my issue #93 ...  This PR also contains the fix from my previous PR ( #95 ).