### PR TITLE
Status plugins invocation fix

### DIFF
--- a/lib/moonshot/controller.rb
+++ b/lib/moonshot/controller.rb
@@ -32,9 +32,10 @@ module Moonshot
     end
 
     def status
-      run_plugins(:status)
+      run_plugins(:pre_status)
       run_hook(:deploy, :status)
       stack.status
+      run_plugins(:post_status)
     end
 
     def deploy_code


### PR DESCRIPTION
Sorry for posting this out of the blue, I just felt like this doesn't really need an issue or a previous discussion. Since documentation states there's a `pre_status` and a `post_status` method available for plugins, I fixed the controller accordingly.