### PR TITLE
CPD-885 Grant access to S3 artifacts created in other accounts.

### DIFF
--- a/lib/moonshot/artifact_repository/s3_bucket.rb
+++ b/lib/moonshot/artifact_repository/s3_bucket.rb
@@ -40,6 +40,7 @@ class Moonshot::ArtifactRepository::S3Bucket
 
   def upload_to_s3(file, key)
     s3_client.put_object(
+      acl: 'bucket-owner-full-control',
       key: key,
       body: File.open(file),
       bucket: @bucket_name,

--- a/moonshot.gemspec
+++ b/moonshot.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |s|
   s.add_dependency('interactive-logger', '~> 0.1.1')
   s.add_dependency('rotp', '~> 2.1.1')
   s.add_dependency('ruby-duration', '~> 3.2.3')
+  # Pin back activesupport (ruby-duration dependency) until we only support
+  # Ruby >= 2.2.2.
+  s.add_dependency('activesupport', '< 5.0.0')
   s.add_dependency('thor', '~> 0.19.1')
   s.add_dependency('semantic')
   s.add_dependency('vandamme')


### PR DESCRIPTION
Previously, files uploaded by other accounts were not accessible by the bucket owner.

For example, if we created deployments in our "production" account, they were unreadable in our "development" account.