### PR TITLE
SSH functionality

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -135,3 +135,9 @@ Tear down your stack by running the following command:
 ```shell
 bundle exec bin/environment delete
 ```
+
+SSH into the first instance in your stack by running the following command:
+
+```shell
+bundle exec bin/environment ssh
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,6 +22,8 @@ methods:
 - post_status
 - pre_doctor
 - post_doctor
+- pre_ssh
+- post_ssh
 
 The method will be handed a single argument, which is an instance of the
 `Moonshot::Resources` class. This instance gives the plugin access to three

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -285,3 +285,32 @@ CodeDeploy
   ✓ CodeDeployRole exists.
   ✓ Resource 'AutoScalingGroup' exists in the CloudFormation template.
 ```
+
+## SSH
+
+SSH into the first or specified instance on the stack.
+
+|Description|Long Form|Short Form|Type|Example|Default|
+|---|---|---|---|---|---|
+|SSH user name|user|l|string|someuser|Environment variable: MOONSHOT_SSH_USER or USER|
+|Private key file for SSH|identity-file|i|string|~/.ssh/whatever|Environment variable: MOONSHOT_SSH_KEY_FILE|
+|Instance ID|instance|s|string|i-04683a82f2dddcc04|(first)|
+|Command to execute|command|c|string|uname -a|open a shell|
+|Auto Scaling Group|auto-scaling-group|g|string|ExampleAppAsg||
+|Environment Name|name|n|string|moonshot-sample-app|None|
+|Interactive Logger|interactive_logger||boolean||true|
+|Verbose|verbose|v|boolean||false|
+
+Example:
+
+```shell
+./bin/environment ssh --name my-service-staging -i ~/.ssh/whatever -c "cat /etc/redhat-release"
+```
+
+Output:
+
+```shell
+Opening SSH connection to i-04683a82f2dddcc04 (123.123.123.123)...
+CentOS Linux release 7.2.1511 (Core)
+Connection to 123.123.123.123 closed.
+```

--- a/lib/moonshot/controller.rb
+++ b/lib/moonshot/controller.rb
@@ -80,6 +80,12 @@ module Moonshot
       success
     end
 
+    def ssh
+      run_plugins(:pre_ssh)
+      stack.ssh
+      run_plugins(:post_ssh)
+    end
+
     def stack
       @stack ||= Stack.new(stack_name,
                            app_name: @config.app_name,
@@ -88,6 +94,11 @@ module Moonshot
         config.parent_stacks = @config.parent_stacks
         config.show_all_events = @config.show_all_stack_events
         config.parameter_strategy = @config.parameter_strategy
+        config.ssh_user = @config.ssh_user
+        config.ssh_identity_file = @config.ssh_identity_file
+        config.ssh_instance = @config.ssh_instance
+        config.ssh_command = @config.ssh_command
+        config.ssh_auto_scaling_group_name = @config.ssh_auto_scaling_group_name
       end
     end
 

--- a/lib/moonshot/controller_config.rb
+++ b/lib/moonshot/controller_config.rb
@@ -15,6 +15,11 @@ module Moonshot
     attr_accessor :plugins
     attr_accessor :show_all_stack_events
     attr_accessor :parameter_strategy
+    attr_accessor :ssh_instance
+    attr_accessor :ssh_identity_file
+    attr_accessor :ssh_user
+    attr_accessor :ssh_command
+    attr_accessor :ssh_auto_scaling_group_name
 
     def initialize
       @auto_prefix_stack = true

--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -93,6 +93,18 @@ module Moonshot
       end
     end
 
+    def ssh
+      box_id = @config.ssh_instance || instances.sort.first
+      box_ip = instance_ip(box_id)
+      cmd = ['ssh', '-t']
+      cmd << "-i #{@config.ssh_identity_file}" if @config.ssh_identity_file
+      cmd << "-l #{@config.ssh_user}" if @config.ssh_user
+      cmd << box_ip
+      cmd << @config.ssh_command if @config.ssh_command
+      puts "Opening SSH connection to #{box_id} (#{box_ip})..."
+      exec(cmd.join(' '))
+    end
+
     def parameters
       get_stack(@name)
         .parameters
@@ -175,6 +187,37 @@ module Moonshot
     end
 
     private
+
+    def asgs
+      resources_of_type('AWS::AutoScaling::AutoScalingGroup')
+    end
+
+    def instance_ip(instance_id)
+      Aws::EC2::Client.new.describe_instances(instance_ids: [instance_id])
+                      .reservations.first.instances.first.public_ip_address
+    rescue
+      raise "Failed to determine public IP address for instance #{instance_id}."
+    end
+
+    def instances # rubocop:disable Metrics/AbcSize
+      groups = asgs
+      asg = if groups.count == 1
+              groups.first
+            elsif asgs.count > 1
+              unless @config.ssh_auto_scaling_group_name
+                raise 'Multiple Auto Scaling Groups found in the stack. Please specify which '\
+                      'one to SSH into using the --auto-scaling-group (-g) option.'
+              end
+              groups.detect { |x| x.logical_resource_id == @config.ssh_auto_scaling_group_name }
+            end
+      raise 'Failed to find the Auto Scaling Group.' unless asg
+
+      Aws::AutoScaling::Client.new.describe_auto_scaling_groups(
+        auto_scaling_group_names: [asg.physical_resource_id]
+      ).auto_scaling_groups.first.instances.map(&:instance_id)
+    rescue
+      raise 'Failed to find instances in the Auto Scaling Group.'
+    end
 
     def stack_name
       "CloudFormation Stack #{@name.blue}"

--- a/lib/moonshot/stack_config.rb
+++ b/lib/moonshot/stack_config.rb
@@ -4,6 +4,11 @@ module Moonshot
     attr_accessor :parent_stacks
     attr_accessor :show_all_events
     attr_accessor :parameter_strategy
+    attr_accessor :ssh_instance
+    attr_accessor :ssh_identity_file
+    attr_accessor :ssh_user
+    attr_accessor :ssh_command
+    attr_accessor :ssh_auto_scaling_group_name
 
     def initialize
       @parent_stacks = []

--- a/spec/moonshot/stack_spec.rb
+++ b/spec/moonshot/stack_spec.rb
@@ -9,6 +9,10 @@ describe Moonshot::Stack do
   subject do
     described_class.new('test', app_name: 'rspec-app', log: log, ilog: ilog) do |c|
       c.parent_stacks = parent_stacks
+      c.ssh_instance = 'i-04683a82f2dddcc04'
+      c.ssh_identity_file = '~/.ssh/whatever'
+      c.ssh_user = 'username'
+      c.ssh_command = 'uname -a'
     end
   end
 
@@ -137,6 +141,17 @@ describe Moonshot::Stack do
     it 'should return the parameters file path' do
       path = File.join(Dir.pwd, 'cloud_formation', 'parameters', 'test.yml')
       expect(subject.parameters_file).to eq(path)
+    end
+  end
+
+  describe '#ssh' do
+    it 'should execute an ssh command with proper parameters' do
+      allow(subject).to receive(:instance_ip).and_return('123.123.123.123')
+      expect(STDOUT).to receive(:puts).with('Opening SSH connection to i-04683a82f2dddcc04 '\
+                                            '(123.123.123.123)...')
+      expect(subject).to receive('exec').with('ssh -t -i ~/.ssh/whatever -l username '\
+                                              '123.123.123.123 uname -a')
+      subject.ssh
     end
   end
 end


### PR DESCRIPTION
Implemented most of the features requested in #72.
By default the `ssh` command selects a random instance from the stack and opens an interactive SSH session. The instance ID, username, private key file and the command can be specified in the command line.

The `#ssh_command` and the `#ssh_options!` methods in `Moonshot::CLI` are there because with the help of them a user can implement custom SSH commands in their CLI tools pretty easily.
Example usage:
```ruby
desc :'sql-cli', 'Jump into mysql console on an instance.'
ssh_options!
def sql_cli
  ssh_command('mysql -u blah')
end
```