### PR TITLE
Refactor SSH functionality.

### DIFF
--- a/lib/moonshot/cli.rb
+++ b/lib/moonshot/cli.rb
@@ -110,8 +110,8 @@ module Moonshot
           config.parameter_strategy = parameter_strategy_factory(parameter_strategy) \
             unless parameter_strategy.nil?
 
-          config.ssh_user = options[:user]
-          config.ssh_identity_file = options[:identity_file]
+          config.ssh_config.ssh_user = options[:user]
+          config.ssh_config.ssh_identity_file = options[:identity_file]
           config.ssh_instance = options[:instance]
           config.ssh_command = options[:command]
           config.ssh_auto_scaling_group_name = options[:auto_scaling_group]

--- a/lib/moonshot/controller_config.rb
+++ b/lib/moonshot/controller_config.rb
@@ -1,4 +1,5 @@
 require_relative 'default_strategy'
+require_relative 'ssh_config'
 
 module Moonshot
   # Holds configuration for Moonshot::Controller
@@ -15,11 +16,10 @@ module Moonshot
     attr_accessor :plugins
     attr_accessor :show_all_stack_events
     attr_accessor :parameter_strategy
-    attr_accessor :ssh_instance
-    attr_accessor :ssh_identity_file
-    attr_accessor :ssh_user
+    attr_accessor :ssh_config
     attr_accessor :ssh_command
     attr_accessor :ssh_auto_scaling_group_name
+    attr_accessor :ssh_instance
 
     def initialize
       @auto_prefix_stack = true
@@ -29,6 +29,7 @@ module Moonshot
       @plugins = []
       @show_all_stack_events = false
       @parameter_strategy = Moonshot::ParameterStrategy::DefaultStrategy.new
+      @ssh_config = SSHConfig.new
     end
   end
 end

--- a/lib/moonshot/ssh_command_builder.rb
+++ b/lib/moonshot/ssh_command_builder.rb
@@ -1,0 +1,32 @@
+require 'shellwords'
+
+module Moonshot
+  # Create an ssh command from configuration.
+  class SSHCommandBuilder
+    Result = Struct.new(:cmd, :ip)
+
+    def initialize(ssh_config, instance_id)
+      @config = ssh_config
+      @instance_id = instance_id
+    end
+
+    def build(command = nil)
+      cmd = ['ssh', '-t']
+      cmd << "-i #{@config.ssh_identity_file}" if @config.ssh_identity_file
+      cmd << "-l #{@config.ssh_user}" if @config.ssh_user
+      cmd << instance_ip
+      cmd << command if command
+      Result.new(cmd.join(' '), instance_ip)
+    end
+
+    private
+
+    def instance_ip
+      @instance_ip ||= Aws::EC2::Client.new
+                                       .describe_instances(instance_ids: [@instance_id])
+                                       .reservations.first.instances.first.public_ip_address
+    rescue
+      raise "Failed to determine public IP address for instance #{@instance_id}!"
+    end
+  end
+end

--- a/lib/moonshot/ssh_config.rb
+++ b/lib/moonshot/ssh_config.rb
@@ -1,0 +1,6 @@
+module Moonshot
+  class SSHConfig # rubocop:disable Documentation
+    attr_accessor :ssh_identity_file
+    attr_accessor :ssh_user
+  end
+end

--- a/lib/moonshot/ssh_target_selector.rb
+++ b/lib/moonshot/ssh_target_selector.rb
@@ -1,0 +1,30 @@
+module Moonshot
+  # Choose a publically accessible instance to run commands on, given a Moonshot::Stack.
+  class SSHTargetSelector
+    def initialize(stack, asg_name: nil)
+      @asg_name = asg_name
+      @stack = stack
+    end
+
+    def choose! # rubocop:disable AbcSize
+      groups = @stack.resources_of_type('AWS::AutoScaling::AutoScalingGroup')
+
+      asg = if groups.count == 1
+              groups.first
+            elsif asgs.count > 1
+              unless @asg_name
+                raise 'Multiple Auto Scaling Groups found in the stack. Please specify which '\
+                      'one to SSH into using the --auto-scaling-group (-g) option.'
+              end
+              groups.detect { |x| x.logical_resource_id == @config.ssh_auto_scaling_group_name }
+            end
+      raise 'Failed to find the Auto Scaling Group.' unless asg
+
+      Aws::AutoScaling::Client.new.describe_auto_scaling_groups(
+        auto_scaling_group_names: [asg.physical_resource_id]
+      ).auto_scaling_groups.first.instances.map(&:instance_id).first
+    rescue
+      raise 'Failed to find instances in the Auto Scaling Group!'
+    end
+  end
+end

--- a/lib/moonshot/stack_config.rb
+++ b/lib/moonshot/stack_config.rb
@@ -4,11 +4,6 @@ module Moonshot
     attr_accessor :parent_stacks
     attr_accessor :show_all_events
     attr_accessor :parameter_strategy
-    attr_accessor :ssh_instance
-    attr_accessor :ssh_identity_file
-    attr_accessor :ssh_user
-    attr_accessor :ssh_command
-    attr_accessor :ssh_auto_scaling_group_name
 
     def initialize
       @parent_stacks = []

--- a/spec/moonshot/build_mechanism/travis_deploy_spec.rb
+++ b/spec/moonshot/build_mechanism/travis_deploy_spec.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module Moonshot # rubocop:disable Metrics/ModuleLength
   describe BuildMechanism::TravisDeploy do
     let(:resources) do
@@ -125,10 +126,11 @@ module Moonshot # rubocop:disable Metrics/ModuleLength
 
       it 'should fail if the job does not complete within the time limit' do
         expect(resources.ilog).to receive(:start_threaded).and_yield(step)
-        expect(step).to receive(:continue)
+        expect(step).to receive(:continue).at_least(9)
         expect(step).to receive(:failure)
+        expect(subject).to receive(:sleep).at_least(:once) { sleep 0.1 }
 
-        subject.instance_variable_set(:@timeout, 5)
+        subject.instance_variable_set(:@timeout, 1)
         subject.send(:wait_for_job, job_number)
       end
     end

--- a/spec/moonshot/ssh_spec.rb
+++ b/spec/moonshot/ssh_spec.rb
@@ -1,0 +1,47 @@
+describe 'Moonshot SSH features' do
+  subject do
+    Moonshot::Controller.new do |c|
+      c.app_name = 'MyApp'
+      c.environment_name = 'prod'
+      c.ssh_config.ssh_user = 'joeuser'
+      c.ssh_config.ssh_identity_file = '/Users/joeuser/.ssh/thegoods.key'
+      c.ssh_command = 'cat /etc/passwd'
+    end
+  end
+
+  describe 'Moonshot::Controller#ssh' do
+    context 'normally' do
+      it 'should execute an ssh command with proper parameters' do
+        ts = instance_double(Moonshot::SSHTargetSelector)
+        expect(Moonshot::SSHTargetSelector).to receive(:new).and_return(ts)
+        expect(ts).to receive(:choose!).and_return('i-04683a82f2dddcc04')
+
+        expect_any_instance_of(Moonshot::SSHCommandBuilder).to receive(:instance_ip).exactly(2)
+          .and_return('123.123.123.123')
+        expect(STDOUT).to receive(:puts)
+          .with('Opening SSH connection to i-04683a82f2dddcc04 (123.123.123.123)...')
+        expect(subject).to receive(:exec)
+          .with('ssh -t -i /Users/joeuser/.ssh/thegoods.key -l joeuser 123.123.123.123 cat /etc/passwd') # rubocop:disable LineLength
+        subject.ssh
+      end
+    end
+
+    context 'when an instance id is given' do
+      subject do
+        c = super()
+        c.config.ssh_instance = 'i-012012012012012'
+        c
+      end
+
+      it 'should execute an ssh command with proper parameters' do
+        expect_any_instance_of(Moonshot::SSHCommandBuilder).to receive(:instance_ip).exactly(2)
+          .and_return('123.123.123.123')
+        expect(STDOUT).to receive(:puts)
+          .with('Opening SSH connection to i-012012012012012 (123.123.123.123)...')
+        expect(subject).to receive(:exec)
+          .with('ssh -t -i /Users/joeuser/.ssh/thegoods.key -l joeuser 123.123.123.123 cat /etc/passwd') # rubocop:disable LineLength
+        subject.ssh
+      end
+    end
+  end
+end

--- a/spec/moonshot/stack_spec.rb
+++ b/spec/moonshot/stack_spec.rb
@@ -9,10 +9,6 @@ describe Moonshot::Stack do
   subject do
     described_class.new('test', app_name: 'rspec-app', log: log, ilog: ilog) do |c|
       c.parent_stacks = parent_stacks
-      c.ssh_instance = 'i-04683a82f2dddcc04'
-      c.ssh_identity_file = '~/.ssh/whatever'
-      c.ssh_user = 'username'
-      c.ssh_command = 'uname -a'
     end
   end
 
@@ -141,17 +137,6 @@ describe Moonshot::Stack do
     it 'should return the parameters file path' do
       path = File.join(Dir.pwd, 'cloud_formation', 'parameters', 'test.yml')
       expect(subject.parameters_file).to eq(path)
-    end
-  end
-
-  describe '#ssh' do
-    it 'should execute an ssh command with proper parameters' do
-      allow(subject).to receive(:instance_ip).and_return('123.123.123.123')
-      expect(STDOUT).to receive(:puts).with('Opening SSH connection to i-04683a82f2dddcc04 '\
-                                            '(123.123.123.123)...')
-      expect(subject).to receive('exec').with('ssh -t -i ~/.ssh/whatever -l username '\
-                                              '123.123.123.123 uname -a')
-      subject.ssh
     end
   end
 end


### PR DESCRIPTION
This patch removes all SSH logic from the stack, instead implementing a few new classes to handle the separate roles of building a command, choosing an instance to connect to and actually doing the connection (which lives in the Controller, for now).

This was needed while I was implementing #124, because the command execution and building were tightly coupled to the stack, and I need to be able to use the building logic without the choosing logic, and do so in a fork.

Includes a test update for Travis tests to reduce rspec runtime by 9 seconds.