### PR TITLE
Fixes #99: Change Stack tagging.

### DIFF
--- a/lib/moonshot/controller.rb
+++ b/lib/moonshot/controller.rb
@@ -3,7 +3,7 @@ require_relative 'ssh_command_builder'
 
 module Moonshot
   # The Controller coordinates and performs all Moonshot actions.
-  class Controller # rubocop:disable ClassLength
+  class Controller
     attr_accessor :config
 
     def initialize
@@ -94,38 +94,10 @@ module Moonshot
     end
 
     def stack
-      @stack ||= Stack.new(stack_name,
-                           app_name: @config.app_name,
-                           ilog: @config.interactive_logger) do |config|
-        config.parent_stacks = @config.parent_stacks
-        config.show_all_events = @config.show_all_stack_events
-        config.parameter_strategy = @config.parameter_strategy
-      end
+      @stack ||= Stack.new(@config)
     end
 
     private
-
-    def default_stack_name
-      user = ENV.fetch('USER').gsub(/\W/, '')
-      "#{@config.app_name}-dev-#{user}"
-    end
-
-    def ensure_prefix(name)
-      if name.start_with?(@config.app_name + '-')
-        name
-      else
-        @config.app_name + "-#{name}"
-      end
-    end
-
-    def stack_name
-      name = @config.environment_name || default_stack_name
-      if @config.auto_prefix_stack == false
-        name
-      else
-        ensure_prefix(name)
-      end
-    end
 
     def resources
       @resources ||=

--- a/lib/moonshot/controller_config.rb
+++ b/lib/moonshot/controller_config.rb
@@ -5,9 +5,9 @@ require_relative 'task'
 module Moonshot
   # Holds configuration for Moonshot::Controller
   class ControllerConfig
+    attr_accessor :additional_tag
     attr_accessor :app_name
     attr_accessor :artifact_repository
-    attr_accessor :auto_prefix_stack
     attr_accessor :build_mechanism
     attr_accessor :deployment_mechanism
     attr_accessor :environment_name
@@ -22,13 +22,15 @@ module Moonshot
     attr_accessor :ssh_instance
 
     def initialize
-      @auto_prefix_stack = true
       @interactive_logger = InteractiveLogger.new
       @parent_stacks = []
       @plugins = []
       @show_all_stack_events = false
       @parameter_strategy = Moonshot::ParameterStrategy::DefaultStrategy.new
       @ssh_config = SSHConfig.new
+
+      user = ENV.fetch('USER', 'default-user').gsub(/\W/, '')
+      @environment_name = "dev-#{user}"
     end
   end
 end


### PR DESCRIPTION
* Updates tags on UpdateStack, as well as CreateStack.
* Uses two new tags: moonshot_application, moonshot_environment.
* Supports an additional tag for internal use, defaults to off.

Because this removes auto_prefix_stack, I'll wait to hear back on the RFC before merging this.