### PR TITLE
Implement first pass at AWS-as-source-of-truth parameters management.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,8 +6,9 @@ AllCops:
     - 'vendor/**/*'
     - 'sample/bin/aws-codedeploy-samples/**/*'
     - 'sample/gems/**/*'
+    - 'spec/**/*'
 Metrics/AbcSize:
-  Max: 30
+  Max: 35
 Metrics/MethodLength:
   Max: 30
 Metrics/LineLength:

--- a/lib/moonshot.rb
+++ b/lib/moonshot.rb
@@ -5,6 +5,10 @@ require 'thor'
 require 'interactive-logger'
 
 module Moonshot
+  class << self
+    attr_writer :config
+  end
+
   def self.config
     @config ||= Moonshot::ControllerConfig.new
     block_given? ? yield(@config) : @config

--- a/lib/moonshot/commands/create.rb
+++ b/lib/moonshot/commands/create.rb
@@ -1,8 +1,14 @@
+require_relative 'parameter_arguments'
+
 module Moonshot
   module Commands
     class Create < Moonshot::Command
+      include ParameterArguments
+
       self.usage = 'create [options]'
       self.description = 'Create a new environment'
+
+      attr_reader :version, :deploy
 
       def parser
         @deploy = true

--- a/lib/moonshot/commands/parameter_arguments.rb
+++ b/lib/moonshot/commands/parameter_arguments.rb
@@ -1,0 +1,22 @@
+module Moonshot
+  module Commands
+    module ParameterArguments
+      def parser
+        parser = super
+
+        parser.on('--answer-file FILE', '-aFILE', 'Load Stack Parameters from a YAML file') do |v|
+          Moonshot.config.answer_file = File.expand_path(v)
+        end
+
+        parser.on('--parameter KEY=VALUE', '-PKEY=VALUE', 'Specify Stack Parameter on the command line') do |v| # rubocop:disable LineLength
+          data = v.split('=', 2)
+          unless data.size == 2
+            raise "Invalid parameter format '#{v}', expected KEY=VALUE (e.g. MyStackParameter=12)"
+          end
+
+          Moonshot.config.parameter_overrides[data[0]] = data[1]
+        end
+      end
+    end
+  end
+end

--- a/lib/moonshot/commands/update.rb
+++ b/lib/moonshot/commands/update.rb
@@ -1,15 +1,12 @@
+require_relative 'parameter_arguments'
+
 module Moonshot
   module Commands
     class Update < Moonshot::Command
+      include ParameterArguments
+
       self.usage = 'update [options]'
       self.description = 'Update the CloudFormation stack within an environment.'
-
-      def parser
-        parser = super
-        parser.on('--parameter-strategy default,merge', 'Override default parameter strategy') do |v| # rubocop:disable LineLength
-          Moonshot.config.parameter_strategy = parameter_strategy_factory(v)
-        end
-      end
 
       def execute
         controller.update

--- a/lib/moonshot/controller.rb
+++ b/lib/moonshot/controller.rb
@@ -1,9 +1,13 @@
 require_relative 'ssh_target_selector'
 require_relative 'ssh_command_builder'
 
+require_relative 'stack_parameter'
+require_relative 'parameter_collection'
+require_relative 'parent_stack_parameter_loader'
+
 module Moonshot
   # The Controller coordinates and performs all Moonshot actions.
-  class Controller
+  class Controller # rubocop:disable ClassLength
     attr_accessor :config
 
     def initialize
@@ -16,7 +20,41 @@ module Moonshot
     end
 
     def create
+      # Scan the template for all required parameters and configure
+      # the ParameterCollection.
+      @config.parameters = ParameterCollection.from_template(stack.template)
+
+      # Import all Outputs from parent stacks as Parameters on this
+      # stack.
+      ParentStackParameterLoader.new(@config).load!
+
+      # If there is an answer file, use it to populate parameters.
+      if @config.answer_file
+        YAML.load_file(@config.answer_file).each do |key, value|
+          @config.parameters[key] = value
+        end
+      end
+
+      # Apply any overrides configured, such as from the CLI -p option.
+      @config.parameter_overrides.each do |key, value|
+        @config.parameters[key] = value
+      end
+
+      # Interview the user for missing parameters, using the
+      # appropriate prompts.
+      # TODO See #148
+
+      # Plugins get the final say on parameters before create,
+      # allowing them to manipulate user supplied input and answers
+      # file content.
       run_plugins(:pre_create)
+
+      # Fail if any parameters are still missing without defaults.
+      missing_parameters = @config.parameters.missing_for_create
+      unless missing_parameters.empty?
+        raise "The following parameters were not provided: #{missing_parameters.map(&:name).join(', ')}" # rubocop:disable LineLength
+      end
+
       run_hook(:deploy, :pre_create)
       stack_ok = stack.create
       if stack_ok # rubocop:disable GuardClause
@@ -26,7 +64,46 @@ module Moonshot
     end
 
     def update
+      # Scan the template for all required parameters and configure
+      # the ParameterCollection.
+      @config.parameters = ParameterCollection.from_template(stack.template)
+
+      # Set all values already provided by the stack to UsePreviousValue.
+      stack.parameters.each do |key, _|
+        @config.parameters[key].use_previous! if @config.parameters.key?(key)
+      end
+
+      # Import all Outputs from parent stacks as Parameters on this
+      # stack.
+      ParentStackParameterLoader.new(@config).load_missing_only!
+
+      # If there is an answer file, use it to populate parameters.
+      if @config.answer_file
+        YAML.load_file(@config.answer_file).each do |key, value|
+          @config.parameters[key] = value
+        end
+      end
+
+      # Apply any overrides configured, such as from the CLI -p option.
+      @config.parameter_overrides.each do |key, value|
+        @config.parameters[key] = value
+      end
+
+      # Interview the user for missing parameters, using the
+      # appropriate prompts.
+      # TODO See #148
+
+      # Plugins get the final say on parameters before create,
+      # allowing them to manipulate user supplied input and answers
+      # file content.
       run_plugins(:pre_update)
+
+      # Fail if any parameters are still missing without defaults.
+      missing_parameters = @config.parameters.missing_for_update
+      unless missing_parameters.empty?
+        raise "The following parameters were not provided: #{missing_parameters.map(&:name).join(', ')}" # rubocop:disable LineLength
+      end
+
       run_hook(:deploy, :pre_update)
       stack.update
       run_hook(:deploy, :post_update)
@@ -41,7 +118,8 @@ module Moonshot
     end
 
     def deploy_code
-      version = "#{stack_name}-#{Time.now.to_i}"
+      version = [@config.app_name, @config.environment_name, Time.now.to_i]
+                .join('-')
       build_version(version)
       deploy_version(version)
     end
@@ -101,7 +179,7 @@ module Moonshot
 
     def resources
       @resources ||=
-        Resources.new(stack: stack, ilog: @config.interactive_logger)
+        Resources.new(stack: stack, ilog: @config.interactive_logger, controller: self)
     end
 
     def run_hook(type, name, *args)

--- a/lib/moonshot/controller_config.rb
+++ b/lib/moonshot/controller_config.rb
@@ -8,23 +8,28 @@ module Moonshot
     attr_accessor :additional_tag
     attr_accessor :app_name
     attr_accessor :artifact_repository
+    attr_accessor :answer_file
     attr_accessor :build_mechanism
     attr_accessor :deployment_mechanism
     attr_accessor :environment_name
+    attr_accessor :interactive
     attr_accessor :interactive_logger
     attr_accessor :parent_stacks
     attr_accessor :plugins
     attr_accessor :show_all_stack_events
-    attr_accessor :parameter_strategy
     attr_accessor :ssh_config
     attr_accessor :ssh_command
     attr_accessor :ssh_auto_scaling_group_name
     attr_accessor :ssh_instance
     attr_accessor :project_root
+    attr_accessor :parameters
+    attr_accessor :parameter_overrides
 
     def initialize
+      @interactive           = true
       @interactive_logger    = InteractiveLogger.new
-      @parameter_strategy    = Moonshot::ParameterStrategy::DefaultStrategy.new
+      @parameters            = ParameterCollection.new
+      @parameter_overrides   = {}
       @parent_stacks         = []
       @plugins               = []
       @project_root          = Dir.pwd

--- a/lib/moonshot/parameter_collection.rb
+++ b/lib/moonshot/parameter_collection.rb
@@ -1,0 +1,50 @@
+module Moonshot
+  # A Rigid Hash-like structure that only accepts manipulation of
+  # parameters defined in the Stack template. Anything else results in
+  # an exception.
+  class ParameterCollection
+    extend Forwardable
+
+    def_delegators :@hash, :key?, :fetch, :[], :keys, :values
+
+    def self.from_template(template)
+      obj = new
+
+      template.parameters.each do |stack_parameter|
+        obj.add(stack_parameter)
+      end
+
+      obj
+    end
+
+    def initialize
+      @hash = {}
+    end
+
+    def []=(key, value)
+      raise "Invalid StackParameter #{key}!" unless @hash.key?(key)
+
+      @hash[key].set(value)
+    end
+
+    def add(parameter)
+      raise ArgumentError, 'Can only add StackParameters!' unless parameter.is_a?(StackParameter)
+
+      @hash[parameter.name] = parameter
+    end
+
+    # What parameters are missing for a CreateStack call, where
+    # UsePreviousValue has no meaning.
+    def missing_for_create
+      # If we haven't set a value, and there is no default, we can't
+      # create the stack.
+      @hash.values.select { |v| !v.set? && !v.default? }
+    end
+
+    def missing_for_update
+      # If we don't have a previous value to use, we haven't set a
+      # value, and there is no default, we can't update a stack.
+      @hash.values.select { |v| !v.set? && !v.default? && !v.use_previous? }
+    end
+  end
+end

--- a/lib/moonshot/parent_stack_parameter_loader.rb
+++ b/lib/moonshot/parent_stack_parameter_loader.rb
@@ -1,0 +1,46 @@
+module Moonshot
+  class ParentStackParameterLoader
+    def initialize(config)
+      @config = config
+    end
+
+    def load!
+      @config.parent_stacks.each do |stack_name|
+        resp = cf_client.describe_stacks(stack_name: stack_name)
+        raise "Parent Stack #{stack_name} not found!" unless resp.stacks.size == 1
+
+        # If there is an input parameters matching a stack output, pass it.
+        resp.stacks[0].outputs.each do |output|
+          next unless @config.parameters.key?(output.output_key)
+          # Our Stack has a Parameter matching this output. Set it's
+          # value to the Output's value.
+          @config.parameters.fetch(output.output_key).set(output.output_value)
+        end
+      end
+    end
+
+    def load_missing_only!
+      @config.parent_stacks.each do |stack_name|
+        resp = cf_client.describe_stacks(stack_name: stack_name)
+        raise "Parent Stack #{stack_name} not found!" unless resp.stacks.size == 1
+
+        # If there is an input parameters matching a stack output, pass it.
+        resp.stacks[0].outputs.each do |output|
+          next unless @config.parameters.key?(output.output_key)
+          # Our Stack has a Parameter matching this output. Set it's
+          # value to the Output's value, but only if we don't already
+          # have a previous value we're using.
+          unless @config.parameters.fetch(output.output_key).use_previous?
+            @config.parameters.fetch(output.output_key).set(output.output_value)
+          end
+        end
+      end
+    end
+
+    private
+
+    def cf_client
+      Aws::CloudFormation::Client.new
+    end
+  end
+end

--- a/lib/moonshot/resources.rb
+++ b/lib/moonshot/resources.rb
@@ -2,11 +2,12 @@ module Moonshot
   # Resources is a dependency container that holds references to instances
   # provided to a Mechanism (build, deploy, etc.).
   class Resources
-    attr_reader :stack, :ilog
+    attr_reader :stack, :ilog, :controller
 
-    def initialize(stack:, ilog:)
+    def initialize(stack:, ilog:, controller:)
       @stack = stack
       @ilog = ilog
+      @controller = controller
     end
   end
 end

--- a/lib/moonshot/stack_parameter.rb
+++ b/lib/moonshot/stack_parameter.rb
@@ -1,0 +1,64 @@
+module Moonshot
+  class StackParameter
+    attr_reader :name
+    attr_reader :default
+
+    def initialize(name, default: nil, use_previous: false)
+      @name = name
+      @default = default
+      @use_previous = use_previous
+      @value = nil
+    end
+
+    # Does this Stack Parameter have a default value that will be used?
+    def default?
+      !@default.nil?
+    end
+
+    def use_previous?
+      @use_previous ? true : false
+    end
+
+    # Has the user provided a value for this parameter?
+    def set?
+      !@value.nil?
+    end
+
+    def set(value)
+      @value = value
+      @use_previous = false
+    end
+
+    def use_previous!
+      if @value
+        raise "Value already set for StackParameter #{@name}, cannot use previous value!"
+      end
+
+      @use_previous = true
+    end
+
+    def value
+      unless @value || default?
+        raise "No value set and no default for StackParameter #{@name}!"
+      end
+
+      if @use_previous
+        raise "StackParameter #{@name} is using previous value, not set!"
+      end
+
+      @value || default
+    end
+
+    def to_cf
+      result = { parameter_key: @name }
+
+      if use_previous?
+        result[:use_previous_value] = true
+      else
+        result[:parameter_value] = value
+      end
+
+      result
+    end
+  end
+end

--- a/lib/moonshot/stack_template.rb
+++ b/lib/moonshot/stack_template.rb
@@ -1,20 +1,16 @@
+require_relative 'stack_parameter'
+
 module Moonshot
   # A StackTemplate loads the template from disk and stores information
   # about it.
   class StackTemplate
-    Parameter = Struct.new(:name, :default) do
-      def required?
-        default.nil?
-      end
-    end
-
     def initialize(filename)
       @filename = filename
     end
 
     def parameters
       template_body.fetch('Parameters', {}).map do |k, v|
-        Parameter.new(k, v['Default'])
+        StackParameter.new(k, default: v['Default'])
       end
     end
 

--- a/spec/fixtures/answer1.yml
+++ b/spec/fixtures/answer1.yml
@@ -1,0 +1,3 @@
+---
+InputParameter2: Answer2
+InputParameter4: Answer4

--- a/spec/fixtures/answer2.yml
+++ b/spec/fixtures/answer2.yml
@@ -1,0 +1,3 @@
+---
+InputParameter3: Answer3
+InputParameter4: Answer4

--- a/spec/fixtures/create1.yml
+++ b/spec/fixtures/create1.yml
@@ -1,0 +1,15 @@
+---
+Resources:
+Parameters:
+  InputParameter1:
+    Type: String
+    Default: 'Default1'
+  InputParameter2:
+    Type: String
+    Default: 'Default2'
+  InputParameter3:
+    Type: String
+  InputParameter4:
+    Type: String
+Outputs:
+  Output1: !Ref "ResourceName"

--- a/spec/fixtures/empty1.yml
+++ b/spec/fixtures/empty1.yml
@@ -1,0 +1,4 @@
+---
+Resources: {}
+Parameters: {}
+Outputs: {}

--- a/spec/fixtures/update1.yml
+++ b/spec/fixtures/update1.yml
@@ -1,0 +1,13 @@
+---
+Resources:
+Parameters:
+  InputParameter1:
+    Type: String
+    Default: 'Default1'
+  InputParameter2:
+    Type: String
+    Default: 'Default2'
+  InputParameter3:
+    Type: String
+Outputs:
+  Output1: !Ref "ResourceName"

--- a/spec/fixtures/update2.yml
+++ b/spec/fixtures/update2.yml
@@ -1,0 +1,15 @@
+---
+Resources:
+Parameters:
+  InputParameter1:
+    Type: String
+    Default: 'Default1'
+  InputParameter2:
+    Type: String
+    Default: 'Default2'
+  InputParameter3:
+    Type: String
+  InputParameter4:
+    Type: String
+Outputs:
+  Output1: !Ref "ResourceName"

--- a/spec/moonshot/build_mechanism/github_release_spec.rb
+++ b/spec/moonshot/build_mechanism/github_release_spec.rb
@@ -8,7 +8,8 @@ module Moonshot # rubocop:disable ModuleLength
     let(:resources) do
       Resources.new(
         ilog: instance_double(InteractiveLogger).as_null_object,
-        stack: instance_double(Stack).as_null_object
+        stack: instance_double(Stack).as_null_object,
+        controller: instance_double(Moonshot::Controller).as_null_object
       )
     end
 

--- a/spec/moonshot/build_mechanism/travis_deploy_spec.rb
+++ b/spec/moonshot/build_mechanism/travis_deploy_spec.rb
@@ -4,7 +4,8 @@ module Moonshot # rubocop:disable Metrics/ModuleLength
     let(:resources) do
       Resources.new(
         ilog: double(InteractiveLogger).as_null_object,
-        stack: double(Stack).as_null_object
+        stack: double(Stack).as_null_object,
+        controller: instance_double(Moonshot::Controller).as_null_object
       )
     end
     let(:slug) { 'myorg/myrepo' }

--- a/spec/moonshot/commands/create_spec.rb
+++ b/spec/moonshot/commands/create_spec.rb
@@ -1,0 +1,26 @@
+describe Moonshot::Commands::Create do
+  before(:each) do
+    Moonshot.config = Moonshot::ControllerConfig.new
+  end
+
+  tests = {
+    %w(-P Key=Value -P OtherKey=OtherValue) => { 'Key' => 'Value', 'OtherKey' => 'OtherValue' },
+    %w(-PKey=ValueWith=Equals) => { 'Key' => 'ValueWith=Equals' }
+  }
+
+  tests.each do |input, expected|
+    it "Should process #{input} correctly" do
+      op = subject.parser
+      op.parse(input)
+      expect(Moonshot.config.parameter_overrides).to match(expected)
+    end
+  end
+
+  it 'should handle version and deploy correctly' do
+    op = subject.parser
+    op.parse(%w(--version 1.2.3 --no-deploy -P Key=Value))
+    expect(subject.version).to eq('1.2.3')
+    expect(subject.deploy).to eq(false)
+    expect(Moonshot.config.parameter_overrides).to match('Key' => 'Value')
+  end
+end

--- a/spec/moonshot/commands/update_spec.rb
+++ b/spec/moonshot/commands/update_spec.rb
@@ -1,0 +1,18 @@
+describe Moonshot::Commands::Update do
+  before(:each) do
+    Moonshot.config = Moonshot::ControllerConfig.new
+  end
+
+  tests = {
+    %w(-P Key=Value -P OtherKey=OtherValue) => { 'Key' => 'Value', 'OtherKey' => 'OtherValue' },
+    %w(-PKey=ValueWith=Equals) => { 'Key' => 'ValueWith=Equals' }
+  }
+
+  tests.each do |input, expected|
+    it "Should process #{input} correctly" do
+      op = subject.parser
+      op.parse(input)
+      expect(Moonshot.config.parameter_overrides).to match(expected)
+    end
+  end
+end

--- a/spec/moonshot/controller_spec.rb
+++ b/spec/moonshot/controller_spec.rb
@@ -1,0 +1,154 @@
+describe 'create' do
+  include_context 'with a CloudFormation stubbed client'
+
+  subject { Moonshot::Controller.new }
+
+  let(:stack) { instance_double(Moonshot::Stack) }
+
+  let(:cf_client_stubs) do
+    {
+      describe_stacks: {
+        stacks: [
+          {
+            stack_name: 'parent-stack-1',
+            creation_time: Time.now,
+            stack_status: 'CREATE_COMPLETE',
+            outputs: [
+              { output_key: 'InputParameter2', output_value: 'Parent2' },
+              { output_key: 'InputParameter3', output_value: 'Parent3' }
+            ]
+          }
+        ]
+      }
+    }
+  end
+
+  before(:each) do
+    expect(Moonshot::Stack).to receive(:new).and_return(stack)
+
+    expect(stack).to receive(:template)
+      .and_return(Moonshot::YamlStackTemplate.new(fixture_path('create1.yml')))
+  end
+
+  # Scenario:
+  #
+  #                  Default | Parent | Answer | Override
+  # InputParameter1     X
+  # InputParameter2     X        X        X
+  # InputParameter3              X
+  # InputParameter4                       X         X
+  #
+  # The rightmost provided value should be used.
+  context 'when parent, answer and overrides are all provided' do
+    it 'use parameter precedent correctly.' do
+      subject.config.parent_stacks = ['parent-stack-1']
+      subject.config.answer_file   = fixture_path('answer1.yml')
+      subject.config.parameter_overrides['InputParameter4'] = 'Override4'
+      expect(stack).to receive(:create)
+
+      subject.create
+
+      pc = subject.config.parameters
+      expect(pc.keys).to eq(%w(InputParameter1 InputParameter2 InputParameter3 InputParameter4))
+
+      expected_create_stack_parameters = [
+        { parameter_key: 'InputParameter1', parameter_value: 'Default1' },
+        { parameter_key: 'InputParameter2', parameter_value: 'Answer2' },
+        { parameter_key: 'InputParameter3', parameter_value: 'Parent3' },
+        { parameter_key: 'InputParameter4', parameter_value: 'Override4' }
+      ]
+      expect(pc.values.map(&:to_cf)).to eq(expected_create_stack_parameters)
+    end
+  end
+
+  # Scenario:
+  #
+  #                  Default | Parent | Answer | Override
+  # InputParameter1     X
+  # InputParameter2     X        X
+  # InputParameter3              X
+  # InputParameter4  ( <-- Not provided )
+  context 'when some parameters are missing, but have no defaults' do
+    it 'should raise an error' do
+      subject.config.parent_stacks = ['parent-stack-1']
+      subject.config.interactive = false
+      expect(stack).not_to receive(:create)
+
+      expect { subject.create }
+        .to raise_error(RuntimeError, 'The following parameters were not provided: InputParameter4')
+
+      pc = subject.config.parameters
+      expect(pc.keys).to eq(%w(InputParameter1 InputParameter2 InputParameter3 InputParameter4))
+
+      expect(pc['InputParameter1'].default?).to eq(true)
+      expect(pc['InputParameter1'].set?).to eq(false)
+      expect(pc['InputParameter1'].value).to eq('Default1')
+
+      expect(pc['InputParameter2'].default?).to eq(true)
+      expect(pc['InputParameter2'].set?).to eq(true)
+      expect(pc['InputParameter2'].value).to eq('Parent2')
+
+      expect(pc['InputParameter3'].default?).to eq(false)
+      expect(pc['InputParameter3'].set?).to eq(true)
+      expect(pc['InputParameter3'].value).to eq('Parent3')
+
+      expect(pc['InputParameter4'].default?).to eq(false)
+      expect(pc['InputParameter4'].set?).to eq(false)
+      expect { pc['InputParameter4'].value }.to raise_error(RuntimeError)
+    end
+  end
+end
+
+describe 'update' do
+  include_context 'with a CloudFormation stubbed client'
+
+  subject { Moonshot::Controller.new }
+
+  let(:stack) { instance_double(Moonshot::Stack) }
+
+  before(:each) do
+    expect(Moonshot::Stack).to receive(:new).and_return(stack)
+
+    expect(stack).to receive(:template)
+      .and_return(Moonshot::YamlStackTemplate.new(fixture_path('create1.yml')))
+  end
+
+  # Scenario:
+  #
+  # Existing stack: InputParameter1, InputParameter2, InputParameter3
+  # New Template: InputParameter1, InputParameter2, InputParameter3, InputParameter4
+  #                  Default | UsePrevious | AnswerFile | Override
+  # InputParameter1     X            X
+  # InputParameter2                  X
+  # InputParameter3                  X            X ( <-- New value from answer file )
+  # InputParameter4                               X           X ( <-- CLI value and Answer value for new parameter)
+  #
+  # The rightmost provided value should be used.
+  context 'when a new parameter is added to the stack with a template' do
+    it 'use parameter precedent correctly.' do
+      subject.config.answer_file = fixture_path('answer2.yml')
+      subject.config.parameter_overrides['InputParameter4'] = 'Override4'
+
+      existing_parameters = {
+        'InputParameter1' => 'Existing1',
+        'InputParameter2' => 'Existing2',
+        'InputParameter3' => 'Existing3'
+      }
+      expect(stack).to receive(:parameters).and_return(existing_parameters)
+      expect(stack).to receive(:update)
+
+      subject.update
+
+      pc = subject.config.parameters
+      expect(pc.keys).to eq(%w(InputParameter1 InputParameter2 InputParameter3 InputParameter4))
+
+      expected_update_stack_parameters = [
+        { parameter_key: 'InputParameter1', use_previous_value: true },
+        { parameter_key: 'InputParameter2', use_previous_value: true },
+        { parameter_key: 'InputParameter3', parameter_value: 'Answer3' },
+        { parameter_key: 'InputParameter4', parameter_value: 'Override4' }
+      ]
+      expect(pc.values.map(&:to_cf)).to eq(expected_update_stack_parameters)
+    end
+  end
+end

--- a/spec/moonshot/plugins_spec.rb
+++ b/spec/moonshot/plugins_spec.rb
@@ -21,6 +21,8 @@ describe 'Plugins support' do
 
   before(:each) do
     expect(Moonshot::Stack).to receive(:new).and_return(stack)
+    template = Moonshot::YamlStackTemplate.new(fixture_path('empty1.yml'))
+    allow(stack).to receive(:template).and_return(template)
   end
 
   it 'calls defined methods on plugins in order, providing them with a Moonshot::Resources' do

--- a/spec/moonshot/shell_spec.rb
+++ b/spec/moonshot/shell_spec.rb
@@ -8,7 +8,8 @@ module Moonshot
     let(:resources) do
       Resources.new(
         ilog: InteractiveLoggerProxy.new(log),
-        stack: double(Stack).as_null_object
+        stack: double(Stack).as_null_object,
+        controller: instance_double(Moonshot::Controller).as_null_object
       )
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,3 +80,20 @@ shared_examples 'with a working moonshot application' do
     FakeFS::FileSystem.clone(File.join(File.dirname(__FILE__), 'fs_fixtures'), '/')
   end
 end
+
+shared_examples 'with a CloudFormation stubbed client' do
+  let(:cf_client_stubs) { {} }
+  let(:cf_client) { Aws::CloudFormation::Client.new(stub_responses: cf_client_stubs) }
+
+  before(:each) do
+    allow(Aws::CloudFormation::Client).to receive(:new).and_return(cf_client)
+  end
+end
+
+def fixture_path(path)
+  File.join(File.dirname(__FILE__), 'fixtures', path)
+end
+
+def fixture(path)
+  File.read(fixture_path(path))
+end


### PR DESCRIPTION
This starts to implement #184, minus the interactive gathering of parameters. Includes testing and I've done quite a bit of testing on my 1.x branch for our project.