### PR TITLE
Add interactive prompting for missing parameters on create/update.

### DIFF
--- a/lib/moonshot.rb
+++ b/lib/moonshot.rb
@@ -56,6 +56,8 @@ end
   'stack_events_poller',
   'merge_strategy',
   'default_strategy',
+  'ask_user_source',
+  'always_use_default_source',
 
   # Built-in mechanisms
   'artifact_repository/s3_bucket',

--- a/lib/moonshot/always_use_default_source.rb
+++ b/lib/moonshot/always_use_default_source.rb
@@ -1,0 +1,17 @@
+module Moonshot
+  # The AlwaysUseDefaultSource will always use the previous value in
+  # the stack, or use the default value during stack creation. This is
+  # useful if plugins provide the value for a parameter, and we don't
+  # want to prompt the user for an override. Of course, overrides from
+  # answer files or command-line arguments will always apply.
+  class AlwaysUseDefaultSource
+    def get(sp)
+      unless sp.default?
+        raise "Parameter #{sp.name} does not have a default, cannot use AlwaysUseDefaultSource!"
+      end
+
+      # Don't do anything, the default will apply on create, and the
+      # previous value will be used on update.
+    end
+  end
+end

--- a/lib/moonshot/ask_user_source.rb
+++ b/lib/moonshot/ask_user_source.rb
@@ -1,0 +1,38 @@
+require 'colorize'
+
+module Moonshot
+  class AskUserSource
+    def get(sp)
+      return unless Moonshot.config.interactive
+
+      @sp = sp
+
+      prompt
+      loop do
+        input = gets.chomp
+
+        if String(input).empty? && @sp.default?
+          # We will use the default value, print it here so the output is clear.
+          puts 'Using default value.'
+          return
+        elsif String(input).empty?
+          puts "Cannot proceed without value for #{@sp.name}!"
+        else
+          @sp.set(String(input))
+          return
+        end
+
+        prompt
+      end
+    end
+
+    private
+
+    def prompt
+      print "(#{@sp.name})".light_black
+      print " #{@sp.description}" unless @sp.description.empty?
+      print " [#{@sp.default}]".light_black if @sp.default?
+      print ': '
+    end
+  end
+end

--- a/lib/moonshot/commands/parameter_arguments.rb
+++ b/lib/moonshot/commands/parameter_arguments.rb
@@ -1,14 +1,19 @@
+# rubocop:disable LineLength
 module Moonshot
   module Commands
     module ParameterArguments
       def parser
         parser = super
 
+        parser.on('--[no-]interactive', TrueClass, 'Use interactive prompts for gathering missing configuration.') do |v|
+          Moonshot.config.interactive = v
+        end
+
         parser.on('--answer-file FILE', '-aFILE', 'Load Stack Parameters from a YAML file') do |v|
           Moonshot.config.answer_file = File.expand_path(v)
         end
 
-        parser.on('--parameter KEY=VALUE', '-PKEY=VALUE', 'Specify Stack Parameter on the command line') do |v| # rubocop:disable LineLength
+        parser.on('--parameter KEY=VALUE', '-PKEY=VALUE', 'Specify Stack Parameter on the command line') do |v|
           data = v.split('=', 2)
           unless data.size == 2
             raise "Invalid parameter format '#{v}', expected KEY=VALUE (e.g. MyStackParameter=12)"

--- a/lib/moonshot/controller_config.rb
+++ b/lib/moonshot/controller_config.rb
@@ -1,6 +1,7 @@
 require_relative 'default_strategy'
 require_relative 'ssh_config'
 require_relative 'task'
+require_relative 'ask_user_source'
 
 module Moonshot
   # Holds configuration for Moonshot::Controller
@@ -18,6 +19,8 @@ module Moonshot
     attr_accessor :parameter_overrides
     attr_accessor :parameters
     attr_accessor :parent_stacks
+    attr_accessor :default_parameter_source
+    attr_accessor :parameter_sources
     attr_accessor :plugins
     attr_accessor :project_root
     attr_accessor :show_all_stack_events
@@ -27,15 +30,17 @@ module Moonshot
     attr_accessor :ssh_instance
 
     def initialize
-      @interactive           = true
-      @interactive_logger    = InteractiveLogger.new
-      @parameters            = ParameterCollection.new
-      @parameter_overrides   = {}
-      @parent_stacks         = []
-      @plugins               = []
-      @project_root          = Dir.pwd
-      @show_all_stack_events = false
-      @ssh_config            = SSHConfig.new
+      @default_parameter_source = AskUserSource.new
+      @interactive              = true
+      @interactive_logger       = InteractiveLogger.new
+      @parameter_overrides      = {}
+      @parameter_sources        = {}
+      @parameters               = ParameterCollection.new
+      @parent_stacks            = []
+      @plugins                  = []
+      @project_root             = Dir.pwd
+      @show_all_stack_events    = false
+      @ssh_config               = SSHConfig.new
 
       @dev_build_name_proc = lambda do |c|
         ['dev', c.app_name, c.environment_name, Time.now.to_i].join('/')

--- a/lib/moonshot/parent_stack_parameter_loader.rb
+++ b/lib/moonshot/parent_stack_parameter_loader.rb
@@ -6,6 +6,8 @@ module Moonshot
 
     def load!
       @config.parent_stacks.each do |stack_name|
+        count = 0
+
         resp = cf_client.describe_stacks(stack_name: stack_name)
         raise "Parent Stack #{stack_name} not found!" unless resp.stacks.size == 1
 
@@ -14,8 +16,11 @@ module Moonshot
           next unless @config.parameters.key?(output.output_key)
           # Our Stack has a Parameter matching this output. Set it's
           # value to the Output's value.
+          count += 1
           @config.parameters.fetch(output.output_key).set(output.output_value)
         end
+
+        puts "Imported #{count} parameters from parent stack #{stack_name.blue}!" if count > 0
       end
     end
 

--- a/lib/moonshot/stack_parameter.rb
+++ b/lib/moonshot/stack_parameter.rb
@@ -2,12 +2,14 @@ module Moonshot
   class StackParameter
     attr_reader :name
     attr_reader :default
+    attr_reader :description
 
-    def initialize(name, default: nil, use_previous: false)
-      @name = name
-      @default = default
+    def initialize(name, default: nil, use_previous: false, description: '')
+      @default      = default
+      @description  = description
+      @name         = name
       @use_previous = use_previous
-      @value = nil
+      @value        = nil
     end
 
     # Does this Stack Parameter have a default value that will be used?
@@ -29,21 +31,19 @@ module Moonshot
       @use_previous = false
     end
 
-    def use_previous!
+    def use_previous!(value)
       if @value
         raise "Value already set for StackParameter #{@name}, cannot use previous value!"
       end
 
+      # Make the current value available to plugins.
+      @value = value
       @use_previous = true
     end
 
     def value
       unless @value || default?
         raise "No value set and no default for StackParameter #{@name}!"
-      end
-
-      if @use_previous
-        raise "StackParameter #{@name} is using previous value, not set!"
       end
 
       @value || default

--- a/lib/moonshot/stack_template.rb
+++ b/lib/moonshot/stack_template.rb
@@ -10,7 +10,9 @@ module Moonshot
 
     def parameters
       template_body.fetch('Parameters', {}).map do |k, v|
-        StackParameter.new(k, default: v['Default'])
+        StackParameter.new(k,
+                           default: v['Default'],
+                           description: v.fetch('Description', ''))
       end
     end
 

--- a/spec/moonshot/plugins_spec.rb
+++ b/spec/moonshot/plugins_spec.rb
@@ -23,6 +23,7 @@ describe 'Plugins support' do
     expect(Moonshot::Stack).to receive(:new).and_return(stack)
     template = Moonshot::YamlStackTemplate.new(fixture_path('empty1.yml'))
     allow(stack).to receive(:template).and_return(template)
+    allow(stack).to receive(:parameters).and_return({})
   end
 
   it 'calls defined methods on plugins in order, providing them with a Moonshot::Resources' do


### PR DESCRIPTION
Some of the improvements in this patch have lead me to a really simple implementation of a really complicated internal plugin we had that used KMS Keys to encrypt parameter values. I'll be putting up another patch to add this feature to core, as an example of how we can use the parameter collections and plugins as a sort of middleware model.