### PR TITLE
Fixes cli debug logging

### DIFF
--- a/lib/moonshot/command.rb
+++ b/lib/moonshot/command.rb
@@ -20,7 +20,7 @@ module Moonshot
         o.banner = "Usage: moonshot #{self.class.usage}"
 
         o.on('-v', '--[no-]verbose', 'Show debug logging') do |v|
-          Moonshot.config.interactive_logger.debug = true if v
+          Moonshot.config.interactive_logger = InteractiveLogger.new(debug: true) if v
         end
 
         o.on('-nNAME', '--environment=NAME', 'Which environment to operate on.') do |v|

--- a/lib/moonshot/commands/console.rb
+++ b/lib/moonshot/commands/console.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 module Moonshot
   module Commands
     class Console < Moonshot::Command

--- a/spec/moonshot/command_spec.rb
+++ b/spec/moonshot/command_spec.rb
@@ -1,0 +1,10 @@
+describe Moonshot::Command do
+  describe '#parser' do
+    subject { described_class.new.parser }
+
+    it 'should work' do
+      allow(described_class).to receive(:usage)
+      subject.parse('-v')
+    end
+  end
+end

--- a/spec/moonshot/command_spec.rb
+++ b/spec/moonshot/command_spec.rb
@@ -2,7 +2,7 @@ describe Moonshot::Command do
   describe '#parser' do
     subject { described_class.new.parser }
 
-    it 'should work' do
+    it 'should parse the verbose option' do
       allow(described_class).to receive(:usage)
       subject.parse('-v')
     end

--- a/spec/moonshot/commands/console_spec.rb
+++ b/spec/moonshot/commands/console_spec.rb
@@ -1,0 +1,12 @@
+describe Moonshot::Commands::Console do
+  describe '#execute' do
+    it 'should start a pry session' do
+      expect(Aws::EC2::Client).to receive(:new)
+      expect(Aws::IAM::Client).to receive(:new)
+      expect(Aws::AutoScaling::Client).to receive(:new)
+      expect(Aws::CloudFormation::Client).to receive(:new)
+      expect(Pry).to receive(:start)
+      subject.execute
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,3 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 if ENV['COVERAGE']
   require 'simplecov'
 


### PR DESCRIPTION
Unfortunately, I don't have the key needed for code climate, but it now needs to be run in travis.yml.
```
This usage of the Code Climate Test Reporter is now deprecated. Since version
1.0, we now require you to run `SimpleCov` in your test/spec helper, and then
run the provided `codeclimate-test-reporter` binary separately to report your
results to Code Climate.

More information here: https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md
```