### PR TITLE
Fix the usege of MOONSHOT_SSH_USER and MOONSHOT_SSH_KEY_FILE environment variables

### DIFF
--- a/lib/moonshot/ssh_config.rb
+++ b/lib/moonshot/ssh_config.rb
@@ -2,5 +2,10 @@ module Moonshot
   class SSHConfig
     attr_accessor :ssh_identity_file
     attr_accessor :ssh_user
+
+    def initialize
+      @ssh_identity_file = ENV['MOONSHOT_SSH_KEY_FILE']
+      @ssh_user = ENV['MOONSHOT_SSH_USER']
+    end
   end
 end


### PR DESCRIPTION
These variables not working after 0.7.7