### PR TITLE
Removes light dark text coloring that is invisible in terminals configured with solarized dark

### DIFF
--- a/lib/moonshot/ask_user_source.rb
+++ b/lib/moonshot/ask_user_source.rb
@@ -29,9 +29,9 @@ module Moonshot
     private
 
     def prompt
-      print "(#{@sp.name})".light_black
+      print "(#{@sp.name})"
       print " #{@sp.description}" unless @sp.description.empty?
-      print " [#{@sp.default}]".light_black if @sp.default?
+      print " [#{@sp.default}]" if @sp.default?
       print ': '
     end
   end

--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -316,7 +316,7 @@ module Moonshot
               event.resource_status.green
             end
       str << " #{event.logical_resource_id}"
-      str << " #{event.resource_status_reason.light_black}" if event.resource_status_reason
+      str << " #{event.resource_status_reason}" if event.resource_status_reason
 
       str
     end

--- a/lib/moonshot/stack_asg_printer.rb
+++ b/lib/moonshot/stack_asg_printer.rb
@@ -141,7 +141,7 @@ module Moonshot
 
     def row_for_activity(activity)
       [
-        activity.start_time.to_s.light_black,
+        activity.start_time.to_s,
         activity.description,
         status_with_color(activity.status_code),
         activity.progress.to_s << '%'

--- a/lib/moonshot/unicode_table.rb
+++ b/lib/moonshot/unicode_table.rb
@@ -39,7 +39,7 @@ module Moonshot
     def draw(depth = 1, first = true)
       print first ? '┌' : '├'
       print '─' * depth
-      puts ' ' << @name.light_black
+      puts ' ' << @name
       @lines = [''] + @lines + ['']
       @lines.each do |line|
         puts '│' << (' ' * depth) << line


### PR DESCRIPTION
This caused me some consternation when I saw:
```
 ❮ bundle exec moonshot update --no-interactive-logger --show-all-events -n njanus
                 :
```
Since this stack parameter had no description, I had no idea what parameter moonshot was asking me to input. Then I highlighted the prompt and discovered that moonshot printed the parameter name.