### PR TITLE
Allow optional arguments for commands

### DIFF
--- a/lib/moonshot/command_line_dispatcher.rb
+++ b/lib/moonshot/command_line_dispatcher.rb
@@ -16,7 +16,8 @@ module Moonshot
       parser = build_parser(handler)
       parser.parse!
 
-      unless @args.size == handler.method(:execute).arity
+      req_arguments = handler.method(:execute).parameters.select { |arg| arg[0] == :req }
+      if ARGV.size < req_arguments.size
         warn handler.parser.help
         raise "Invalid command line for '#{@command}'."
       end

--- a/spec/moonshot/command_optional_argument_spec.rb
+++ b/spec/moonshot/command_optional_argument_spec.rb
@@ -1,0 +1,25 @@
+class OptionalArgumentCommand < Moonshot::Command
+  def execute(version = 'development')
+    puts "selected version: #{version}"
+  end
+end
+
+describe 'optional argument for command' do
+  def try(klass, args = [])
+    Moonshot::CommandLineDispatcher.new('stuff', klass, args)
+      .dispatch!
+  end
+
+  Moonshot::AccountContext.set('optional-account')
+  ARGV.clear
+
+  it 'should let us run OptionalArgumentCommand without extra arguments' do
+    expect { try(OptionalArgumentCommand) }
+      .to output(/selected version: development/).to_stdout
+  end
+
+  it 'should let us run OptionalArgumentCommand with extra argument' do
+    expect { try(OptionalArgumentCommand, ['production']) }
+      .to output(/selected version: production/).to_stdout
+  end
+end


### PR DESCRIPTION
This patch allows us to use optional arguments on `execute` like this one:

```
moonshot reset [version] [options]

moonshot reset                   # for development version
moonshot reset my_custom_version # for custom version
```