### PR TITLE
Allow custom configuration through Moonfile.rb with config.custom

### DIFF
--- a/lib/moonshot/controller_config.rb
+++ b/lib/moonshot/controller_config.rb
@@ -28,6 +28,8 @@ module Moonshot
     attr_accessor :ssh_command
     attr_accessor :ssh_config
     attr_accessor :ssh_instance
+    # Custom configuration for custom commands
+    attr_accessor :custom
 
     def initialize
       @default_parameter_source = AskUserSource.new
@@ -41,6 +43,7 @@ module Moonshot
       @project_root             = Dir.pwd
       @show_all_stack_events    = false
       @ssh_config               = SSHConfig.new
+      @custom                   = {}
 
       @dev_build_name_proc = lambda do |c|
         ['dev', c.app_name, c.environment_name, Time.now.to_i].join('/')


### PR DESCRIPTION
This patch allows us to add custom configuration entries if custom commands wants to use them in general like "Is this a production stack?"

```ruby
## Moonfile.rb

production_accounts = ['dev-aws-account', 'dev2-aws-account']

Moonshot.config do |c|
  current_aws_account = Aws::IAM::Client.new.list_account_aliases.account_aliases.first
  c.custom['is_production'] = production_accounts.include?(current_aws_account)
end

## my_command.rb

class MyCommand << Moonshot::Command
  self.description = 'Do something dangerous.'
  def execute
    if controller.config.custom['is_production']
      raise "This command is not allowed in production environment" 
    end
    do_something
  end
end
```