### PR TITLE
require optionparser, not thor

### DIFF
--- a/lib/moonshot/command.rb
+++ b/lib/moonshot/command.rb
@@ -1,4 +1,4 @@
-require 'thor'
+require 'optionparser'
 
 module Moonshot
   # A Command that is automatically registered with the Moonshot::CommandLine


### PR DESCRIPTION
The require is for thor, but we are using OptionParser..
```
$ moonshot status
uninitialized constant Moonshot::Command::OptionParser (at /home/pb/.rvm/gems/ruby-2.3.3/gems/moonshot-2.0.0.beta1/lib/moonshot/command.rb:19:in `parser')
/home/pb/.rvm/gems/ruby-2.3.3/gems/moonshot-2.0.0.beta1/lib/moonshot/command.rb:19:in `parser': uninitialized constant Moonshot::Command::OptionParser (NameError)
	from /home/pb/.rvm/gems/ruby-2.3.3/gems/moonshot-2.0.0.beta1/lib/moonshot/command_line_dispatcher.rb:45:in `build_parser'
	from /home/pb/.rvm/gems/ruby-2.3.3/gems/moonshot-2.0.0.beta1/lib/moonshot/command_line_dispatcher.rb:16:in `dispatch!'
	from /home/pb/.rvm/gems/ruby-2.3.3/gems/moonshot-2.0.0.beta1/lib/moonshot/command_line.rb:68:in `run!'
	from /home/pb/.rvm/gems/ruby-2.3.3/gems/moonshot-2.0.0.beta1/bin/moonshot:6:in `<top (required)>'
	from /home/pb/.rvm/gems/ruby-2.3.3/bin/moonshot:22:in `load'
	from /home/pb/.rvm/gems/ruby-2.3.3/bin/moonshot:22:in `<main>'
	from /home/pb/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `eval'
	from /home/pb/.rvm/gems/ruby-2.3.3/bin/ruby_executable_hooks:15:in `<main>'
```