### PR TITLE
Optparse and Thor not required correctly

### DIFF
--- a/lib/moonshot/command.rb
+++ b/lib/moonshot/command.rb
@@ -1,4 +1,4 @@
-require 'thor'
+require 'optparse'
 
 module Moonshot
   # A Command that is automatically registered with the Moonshot::CommandLine

--- a/lib/moonshot/shell.rb
+++ b/lib/moonshot/shell.rb
@@ -1,3 +1,5 @@
+require 'thor'
+
 # Mixin providing the Thor::Shell methods and other shell execution helpers.
 module Moonshot::Shell
   # Run a command, returning stdout. Stderr is suppressed unless the command


### PR DESCRIPTION
Testing moonshot 2.0.0 beta1 on xenial using default ruby version
of 2.3 and moonshot is unable to work due to command and shell not
requiring OptParse and Thor correctly.

This resolves #201