### PR TITLE
Fix status command if there's a standby instance in the ASG

### DIFF
--- a/lib/moonshot/stack_asg_printer.rb
+++ b/lib/moonshot/stack_asg_printer.rb
@@ -111,19 +111,18 @@ module Moonshot
     end
 
     def instance_row(asg_instance, ec2_instance)
-      public_ip = if ec2_instance
-                    if ec2_instance.public_ip_address
-                      ec2_instance.public_ip_address
-                    else
-                      "#{ec2_instance.private_ip_address} (PRV)"
-                    end
-                  else
-                    'offline'
-                  end
-      uptime = ec2_instance.nil? ? 'offline' : uptime_format(ec2_instance.launch_time)
+      if ec2_instance
+        ip_address = ec2_instance.public_ip_address || "#{ec2_instance.private_ip_address} (PRV)"
+        uptime = uptime_format(ec2_instance.launch_time)
+      else
+        # We've seen race conditions where ASG tells us about instances that EC2 is no longer
+        # aware of.
+        ip_address = 'unknown'
+        uptime = 'unknown'
+      end
       [
         asg_instance.instance_id,
-        public_ip,
+        ip_address,
         lifecycle_color(asg_instance.lifecycle_state),
         health_color(asg_instance.health_status),
         uptime

--- a/lib/moonshot/stack_asg_printer.rb
+++ b/lib/moonshot/stack_asg_printer.rb
@@ -111,13 +111,22 @@ module Moonshot
     end
 
     def instance_row(asg_instance, ec2_instance)
+      public_ip = if ec2_instance
+                    if ec2_instance.public_ip_address
+                      ec2_instance.public_ip_address
+                    else
+                      "#{ec2_instance.private_ip_address} (PRV)"
+                    end
+                  else
+                    'offline'
+                  end
+      uptime = ec2_instance.nil? ? 'offline' : uptime_format(ec2_instance.launch_time)
       [
         asg_instance.instance_id,
-        # @todo What about ASGs with only private IPs?
-        ec2_instance.public_ip_address,
+        public_ip,
         lifecycle_color(asg_instance.lifecycle_state),
         health_color(asg_instance.health_status),
-        uptime_format(ec2_instance.launch_time)
+        uptime
       ]
     end
 


### PR DESCRIPTION
This fixes an issue when there's a standby instance in one of the ASGs.

```
$ moonshot status
┌─ CodeDeploy Application: app-dev-user
│
│ Application and Deployment Group are configured correctly.
│
└──
CloudFormation Stack app-dev-user exists.
undefined method `public_ip_address' for nil:NilClass
Did you mean?  public_send (at /home/user/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/moonshot-494af420cef0/lib/moonshot/stack_asg_printer.rb:117:in `instance_row')
```