### PR TITLE
Parent stacks command only allowing one parent

### DIFF
--- a/lib/moonshot/commands/parent_stack_option.rb
+++ b/lib/moonshot/commands/parent_stack_option.rb
@@ -8,6 +8,11 @@ module Moonshot
                   'Parent stack to import parameters from') do |v|
           Moonshot.config.parent_stacks = [v]
         end
+
+        parser.on('--parents a,b,c', Array,
+                  'List of parent stacks to import parameters from') do |v|
+          Moonshot.config.parent_stacks = v
+        end
       end
     end
   end

--- a/spec/moonshot/commands/create_spec.rb
+++ b/spec/moonshot/commands/create_spec.rb
@@ -23,4 +23,11 @@ describe Moonshot::Commands::Create do
     expect(subject.deploy).to eq(false)
     expect(Moonshot.config.parameter_overrides).to match('Key' => 'Value')
   end
+
+  it 'should process multiple parent stacks' do
+    op = subject.parser
+    op.parse(%w(--parents parent1,parent2,parent3 --no-deploy))
+    expect(subject.deploy).to eq(false)
+    expect(Moonshot.config.parent_stacks.count).to be(3)
+  end
 end


### PR DESCRIPTION
Bug in the option parser where it was only pushing one
parent stack from the command line even through the config
loader would later loop over all parents provided.