### PR TITLE
Sort and format stack output printer

### DIFF
--- a/lib/moonshot/stack_output_printer.rb
+++ b/lib/moonshot/stack_output_printer.rb
@@ -8,9 +8,10 @@ module Moonshot
 
     def print
       o_table = @table.add_leaf('Stack Outputs')
-      @stack.outputs.each do |k, v|
-        o_table.add_line("#{k}: #{v}")
+      rows = @stack.outputs.sort.map do |key, value|
+        ["#{key}:", value]
       end
+      o_table.add_table(rows)
     end
   end
 end


### PR DESCRIPTION
I essentially copied the parameter printer over because I like purdy output.

This raised a question though. Why do we [truncate the parameter output](https://github.com/acquia/moonshot/blob/master/lib/moonshot/stack_parameter_printer.rb#L21) at all? I see from the last commit that this was enlarged from 40 to 60, but I think that being able to read all of the parameters a stack was configured with, unadulterated, as being a good thing. I didn't port `format_value` across because it could render output values useless.