### PR TITLE
Update capabilities to support named iam

### DIFF
--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -180,7 +180,7 @@ module Moonshot
       cf_client.create_stack(
         stack_name: @name,
         template_body: template.body,
-        capabilities: ['CAPABILITY_IAM'],
+        capabilities: %w(CAPABILITY_IAM CAPABILITY_NAMED_IAM),
         parameters: @config.parameters.values.map(&:to_cf),
         tags: make_tags
       )
@@ -200,7 +200,7 @@ module Moonshot
         description: "Moonshot update command for application '#{Moonshot.config.app_name}'",
         stack_name: @name,
         template_body: template.body,
-        capabilities: ['CAPABILITY_IAM'],
+        capabilities:  %w(CAPABILITY_IAM CAPABILITY_NAMED_IAM),
         parameters: @config.parameters.values.map(&:to_cf)
       )
 

--- a/spec/moonshot/stack_spec.rb
+++ b/spec/moonshot/stack_spec.rb
@@ -66,7 +66,7 @@ describe Moonshot::Stack do
             { key: 'ah_stage', value: 'rspec-app-staging' }
           ],
           parameters: [],
-          capabilities: ['CAPABILITY_IAM']
+          capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM']
         }
       end
 


### PR DESCRIPTION
Updated create and update stack to support all possibile IAM
capabilities.

From AWS docs: If you have IAM resources, you can specify either capability. If you have IAM resources with custom names, you must specify CAPABILITY_NAMED_IAM. If you don't specify this parameter, this action returns an InsufficientCapabilities error.