### PR TITLE
Added support for changing changeset wait time

### DIFF
--- a/lib/moonshot/change_set.rb
+++ b/lib/moonshot/change_set.rb
@@ -76,7 +76,10 @@ module Moonshot
     # NOTE: At the time of this patch, AWS-SDK native Waiters do not
     # have support for ChangeSets. Once they add this, we can make
     # this code much better.
+    # Still no support for this waiter, but it's planned.
+    # https://github.com/aws/aws-sdk-ruby/issues/1388
     def wait_for_change_set
+      wait_seconds = Moonshot.config.changeset_wait_time || 30
       start = Time.now.to_i
 
       loop do
@@ -89,11 +92,11 @@ module Moonshot
           return
         end
 
-        if Time.now.to_i > start + 30
-          raise 'ChangeSet did not complete creation within 30 seconds!'
+        if Time.now.to_i > start + wait_seconds
+          raise "ChangeSet did not complete creation within #{wait_seconds} seconds!"
         end
 
-        sleep 0.25 # http://bit.ly/1qY1ZXJ
+        sleep 5 # http://bit.ly/1qY1ZXJ
       end
     end
   end

--- a/lib/moonshot/change_set.rb
+++ b/lib/moonshot/change_set.rb
@@ -79,7 +79,7 @@ module Moonshot
     # Still no support for this waiter, but it's planned.
     # https://github.com/aws/aws-sdk-ruby/issues/1388
     def wait_for_change_set
-      wait_seconds = Moonshot.config.changeset_wait_time || 30
+      wait_seconds = Moonshot.config.changeset_wait_time || 90
       start = Time.now.to_i
 
       loop do

--- a/lib/moonshot/change_set.rb
+++ b/lib/moonshot/change_set.rb
@@ -97,6 +97,9 @@ module Moonshot
         end
 
         sleep 5 # http://bit.ly/1qY1ZXJ
+        # Wait 5 seconds because other waiters seem to wait at least 5 seconds
+        # before repeating requests.
+        # See: https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/apis/cloudformation/2010-05-15/waiters-2.json#L5
       end
     end
   end

--- a/lib/moonshot/controller_config.rb
+++ b/lib/moonshot/controller_config.rb
@@ -8,6 +8,7 @@ module Moonshot
     attr_accessor :app_name
     attr_accessor :artifact_repository
     attr_accessor :build_mechanism
+    attr_accessor :changeset_wait_time
     attr_accessor :deployment_mechanism
     attr_accessor :dev_build_name_proc
     attr_accessor :environment_name


### PR DESCRIPTION
AWS sometimes fails to create a changeset in 30 seconds when we're running a `moonshot update`, causing our release jobs to fail.

The following has been implemented in this PR:
- Changeset wait time is now configurable, defaults to 90 seconds.
```moonfile.rb
Moonshot.config do |c|
  ...
  c.changeset_wait_time = 120
end
```
- Slowed down science a bit since [other waiters seem to wait at least 5 seconds](https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/apis/cloudformation/2010-05-15/waiters-2.json#L5) before repeating requests.