### PR TITLE
Output the private IP regardless of an instance's public IP.

### DIFF
--- a/lib/moonshot/stack_asg_printer.rb
+++ b/lib/moonshot/stack_asg_printer.rb
@@ -112,7 +112,11 @@ module Moonshot
 
     def instance_row(asg_instance, ec2_instance)
       if ec2_instance
-        ip_address = ec2_instance.public_ip_address || "#{ec2_instance.private_ip_address} (PRV)"
+        if ec2_instance.public_ip_address
+          ip_address = "#{ec2_instance.public_ip_address} (#{ec2_instance.private_ip_address})"
+        else
+          ip_address = "#{ec2_instance.private_ip_address} (PRV)"
+        end
         uptime = uptime_format(ec2_instance.launch_time)
       else
         # We've seen race conditions where ASG tells us about instances that EC2 is no longer


### PR DESCRIPTION
For compliance, among many other, reasons it is best practice to use a jump host to access remote networks.

Currently the output of `moonshot status` only shows the external IP of an instance, when present, which is impossible to use for ssh, when on that private network. Outputting the private IP makes it easier for an admin to find and connect to a valid instance in an ASG.

Please let me know if you'd prefer a different format for the output :)