### PR TITLE
Add lib/default when building gem

### DIFF
--- a/moonshot.gemspec
+++ b/moonshot.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'moonshot'
-  s.version     = '2.0.0.beta2'
+  s.version     = '2.0.0.beta3'
   s.licenses    = ['Apache-2.0']
   s.summary     = 'A library and CLI tool for launching services into AWS'
   s.description = 'A library and CLI tool for launching services into AWS.'
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
     'Cloud Engineering <engineering@acquia.com>'
   ]
   s.email       = 'engineering@acquia.com'
-  s.files       = Dir['lib/**/*.rb'] + Dir['bin/*']
+  s.files       = Dir['lib/**/*.rb'] + Dir['lib/default/**/*'] + Dir['bin/*']
   s.bindir      = 'bin'
   s.executables = ['moonshot']
   s.homepage    = 'https://github.com/acquia/moonshot'


### PR DESCRIPTION
So, this was lulz. The published gem didn't contain any of the default files copied in to place with `moonshot new $foo`, with exception of `Moonfile.rb`

```
$ ls ~/.rvm/gems/ruby-2.3.3/gems/moonshot-2.0.0.beta2/lib/default/
Moonfile.rb
$
```