### PR TITLE
Make it possible to specify the backup bucket region.

### DIFF
--- a/lib/plugins/backup.rb
+++ b/lib/plugins/backup.rb
@@ -14,7 +14,8 @@ module Moonshot
                     :hooks,
                     :target_name,
                     :backup_parameters,
-                    :backup_template
+                    :backup_template,
+                    :bucket_region
 
       def initialize
         yield self if block_given?
@@ -162,7 +163,9 @@ module Moonshot
       #
       # @param io_zip [IO] tar stream
       def upload(io_zip)
-        s3_client.put_object(
+        opts = {}
+        opts[:region] = @bucket_region if @bucket_region
+        s3_client(opts).put_object(
           acl: 'private',
           bucket: @target_bucket,
           key: @target_name,

--- a/spec/moonshot/plugins/backup_spec.rb
+++ b/spec/moonshot/plugins/backup_spec.rb
@@ -20,10 +20,12 @@ describe Moonshot::Plugins::Backup do
     it 'should yield self' do
       backup = subject.new do |b|
         b.bucket = 'test'
+        b.bucket_region = 'us-east-2'
         b.files = %w(sample files)
         b.hooks = [:sample, :hooks]
       end
       expect(backup.bucket).to eq('test')
+      expect(backup.bucket_region).to eq('us-east-2')
       expect(backup.files).to eq(%w(sample files))
       expect(backup.hooks).to eq([:sample, :hooks])
     end


### PR DESCRIPTION
Buckets are specific to a region.  Currently, specifying a bucket in region A and then running moonshot in region B will fail to execute the backup.