### PR TITLE
Added rdoc dependency

### DIFF
--- a/moonshot.gemspec
+++ b/moonshot.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency('vandamme')
   s.add_dependency('pry')
   s.add_dependency('require_all')
+  s.add_dependency('rdoc')
 
   s.add_development_dependency('rspec')
   s.add_development_dependency('simplecov')


### PR DESCRIPTION
Hi,

while I was creating an alpine-based docker container I found out that moonshot actually needs rdoc as a dependency, otherwise it fails with the following error:

```
bash-4.3# moonshot version
/usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- rdoc (LoadError)
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/gems/2.4.0/gems/github-markup-1.6.1/lib/github/markup/rdoc.rb:2:in `<top (required)>'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/gems/2.4.0/gems/github-markup-1.6.1/lib/github/markups.rb:2:in `<module:Markup>'
        from /usr/lib/ruby/gems/2.4.0/gems/github-markup-1.6.1/lib/github/markup.rb:102:in `instance_eval'
        from /usr/lib/ruby/gems/2.4.0/gems/github-markup-1.6.1/lib/github/markup.rb:102:in `<module:Markup>'
        from /usr/lib/ruby/gems/2.4.0/gems/github-markup-1.6.1/lib/github/markup.rb:24:in `<module:GitHub>'
        from /usr/lib/ruby/gems/2.4.0/gems/github-markup-1.6.1/lib/github/markup.rb:10:in `<top (required)>'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/gems/2.4.0/gems/vandamme-0.0.12/lib/vandamme/parser.rb:2:in `<top (required)>'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/gems/2.4.0/gems/vandamme-0.0.12/lib/vandamme.rb:2:in `<top (required)>'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/gems/2.4.0/gems/moonshot-2.0.0.beta3/lib/moonshot/build_mechanism/github_release.rb:7:in `<top (required)>'
        from /usr/lib/ruby/gems/2.4.0/gems/require_all-1.4.0/lib/require_all.rb:108:in `require'
        from /usr/lib/ruby/gems/2.4.0/gems/require_all-1.4.0/lib/require_all.rb:108:in `block in require_all'
        from /usr/lib/ruby/gems/2.4.0/gems/require_all-1.4.0/lib/require_all.rb:106:in `each'
        from /usr/lib/ruby/gems/2.4.0/gems/require_all-1.4.0/lib/require_all.rb:106:in `require_all'
        from /usr/lib/ruby/gems/2.4.0/gems/require_all-1.4.0/lib/require_all.rb:153:in `block in require_rel'
        from /usr/lib/ruby/gems/2.4.0/gems/require_all-1.4.0/lib/require_all.rb:152:in `each'
        from /usr/lib/ruby/gems/2.4.0/gems/require_all-1.4.0/lib/require_all.rb:152:in `require_rel'
        from /usr/lib/ruby/gems/2.4.0/gems/moonshot-2.0.0.beta3/lib/moonshot.rb:28:in `<top (required)>'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/lib/ruby/gems/2.4.0/gems/moonshot-2.0.0.beta3/bin/moonshot:2:in `<top (required)>'
        from /usr/bin/moonshot:22:in `load'
        from /usr/bin/moonshot:22:in `<main>'
```

Or is it actually a missing dependency in github-markup? It may be a bug in that project.