### PR TITLE
Refactor paramater overriding. Set default parameter file

### DIFF
--- a/lib/moonshot/controller.rb
+++ b/lib/moonshot/controller.rb
@@ -11,7 +11,7 @@ module Moonshot
       Moonshot::StackLister.new(@config.app_name).list
     end
 
-    def create # rubocop:disable AbcSize
+    def create
       # Scan the template for all required parameters and configure
       # the ParameterCollection.
       @config.parameters = ParameterCollection.from_template(stack.template)
@@ -20,17 +20,8 @@ module Moonshot
       # stack.
       ParentStackParameterLoader.new(@config).load!
 
-      # If there is an answer file, use it to populate parameters.
-      if @config.answer_file
-        YAML.load_file(@config.answer_file).each do |key, value|
-          @config.parameters[key] = value
-        end
-      end
-
-      # Apply any overrides configured, such as from the CLI -p option.
-      @config.parameter_overrides.each do |key, value|
-        @config.parameters[key] = value
-      end
+      # Override Parameters from default then defined answer_file, then cli input params
+      @config = ParameterCollection.apply_overrides(@config)
 
       # Interview the user for missing parameters, using the
       # appropriate prompts.
@@ -78,17 +69,8 @@ module Moonshot
       parent_stack_params = ParentStackParameterLoader.new(@config)
       refresh_parameters ? parent_stack_params.load! : parent_stack_params.load_missing_only!
 
-      # If there is an answer file, use it to populate parameters.
-      if @config.answer_file
-        YAML.load_file(@config.answer_file).each do |key, value|
-          @config.parameters[key] = value
-        end
-      end
-
-      # Apply any overrides configured, such as from the CLI -p option.
-      @config.parameter_overrides.each do |key, value|
-        @config.parameters[key] = value
-      end
+      # Override Parameters from default then defined answer_file, then cli input params
+      @config = ParameterCollection.apply_overrides(@config)
 
       # Interview the user for missing parameters, using the
       # appropriate prompts.

--- a/lib/moonshot/parameter_collection.rb
+++ b/lib/moonshot/parameter_collection.rb
@@ -17,6 +17,34 @@ module Moonshot
       obj
     end
 
+    def self.apply_overrides(config)
+      raise unless config.instance_of?(Moonshot::ControllerConfig)
+
+      default_answer_file = File.join(config.project_root,
+                                      'moonshot',
+                                      'params',
+                                      "#{config.environment_name}.yml")
+
+      answer_file = config.answer_file ? config.answer_file : default_answer_file
+
+      # The order we override parameters in is, in order of least to most important:
+      #   * project_root/moonshot/params/#{environment}.yml
+      #   * file defined by the user with -a/--answer-file
+      #   * individual parameters the user input with -P/--parameter
+      #
+      if File.readable?(answer_file)
+        YAML.load_file(answer_file).each do |key, value|
+          config.parameters[key] = value
+        end
+      end
+
+      config.parameter_overrides.each do |key, value|
+        config.parameters[key] = value
+      end
+
+      config
+    end
+
     def initialize
       @hash = {}
     end


### PR DESCRIPTION
So, I'm not 100% happy with this because it doesn't feel like the best writing of it, but it's been a while since I had to type out some ruby and some how I managed to fix a rubocop override! :D

We automatically load files from other folders inside of `moonshot/`, so why not also try and load a parameter file? If there is a better way of doing this I'd be welcoming of feedback, or if someone wants to Nike it that'd be fine also.