### PR TITLE
CPD-1298 | As a cloud data engineer, I would to able to skip the SHA status check when building a release.

### DIFF
--- a/docs/mechanisms/build.md
+++ b/docs/mechanisms/build.md
@@ -33,6 +33,26 @@ Moonshot.config do |c|
 ...
 ```
 
+**skip_ci_status** is an optional flag. It would allow us to skip checks 
+on the commit's CI job status. Without this option, the GithubRelease mechanism will wait until the build is finished.
+
+Sample Usage
+
+```ruby
+Moonshot.config do |c|
+  wait_for_travis_mechanism = TravisDeploy.new("acquia/moonshot", true)
+  c.build_mechanism = GithubRelease.new(wait_for_travis_mechanism, skip_ci_status: true)
+...
+```
+Also a command-line option is available to override this value.
+
+	Usage: moonshot build VERSION
+	    -v, --[no-]verbose               Show debug logging
+	    -s, --skip-ci-status             Skip checks on CI jobs
+	    -n, --environment=NAME           Which environment to operate on.
+		--[no-]interactive-logger    Enable or disable fancy logging
+	    -F, --foo    
+
 ## TravisDeploy
 
 The Travis Build Mechanism waits for Travis-CI to finish building a

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -67,6 +67,7 @@ new command line option:
 ```
 Usage: moonshot build VERSION
     -v, --[no-]verbose               Show debug logging
+    -s, --skip-ci-status             Skip checks on CI jobs
     -n, --environment=NAME           Which environment to operate on.
         --[no-]interactive-logger    Enable or disable fancy logging
     -F, --foo                        ENABLE HYPERDRIVE

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -16,6 +16,13 @@ Display debug logging. The types of things logged here are mostly
 useful only for core Moonshot developers, or if you are working on
 custom plugins.
 
+## `--skip-ci-status / -s`
+
+*Default: Disabled*
+
+It would allow us to skip checks on the commit's CI job status. 
+Without this option, the GithubRelease mechanism will wait until the build is finished.
+
 #### `--environment=NAME / -n NAME`
 
 *Default: dev-$USER, or as specified in the `environment_name`

--- a/spec/moonshot/build_mechanism/github_release_spec.rb
+++ b/spec/moonshot/build_mechanism/github_release_spec.rb
@@ -189,5 +189,28 @@ module Moonshot # rubocop:disable ModuleLength
         expect { subject.send(:check_ci_status, sha) }.to raise_error(Shell::CommandError)
       end
     end
+    
+    describe '#validate_commit' do
+      let(:skip_ci) { false }
+      subject { 
+        s = described_class.new(build_mechanism, skip_ci_status: skip_ci);
+        s.resources = resources
+        s
+      }
+      
+      it 'calls check_ci_status' do
+        expect(subject).to receive(:check_ci_status)
+        subject.send(:validate_commit)
+      end
+
+      context 'when skip_ci_status is true' do
+        let(:skip_ci) { true }
+        it 'does not call check_ci_status' do
+          expect(subject).not_to receive(:check_ci_status)           
+          subject.send(:validate_commit)
+        end
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Testing Steps:
==

1. cd moonshot/lib/default
2. check --help without GithubRelease plugin

```
moonshot deploy --help 
Usage: moonshot deploy VERSION
    -v, --[no-]verbose               Show debug logging
    -n, --environment=NAME           Which environment to operate on.
        --[no-]interactive-logger    Enable or disable fancy logging
        --[no-]interactive           Use interactive prompts.
```
3. register github plugin by update Moonfile.rb with below content

```
Moonshot.config do |c|
  c.build_mechanism = GithubRelease.new('')
  c.deployment_mechanism = CodeDeploy.new(asg: 'AutoScalingGroup')
end
```
4- check --help again 
```
moonshot deploy --help 
Usage: moonshot deploy VERSION
    -v, --[no-]verbose               Show debug logging
    -n, --environment=NAME           Which environment to operate on.
        --[no-]interactive-logger    Enable or disable fancy logging
        --[no-]interactive           Use interactive prompts.
    -s, --skip-ci-status             Skips checks on CI jobs
        --ignore-app-stop-failures   Continue deployment on ApplicationStop failures
```