### PR TITLE
CPD-2350 | Add the skip_ci_status option to the github release mechanism in build command

### DIFF
--- a/lib/moonshot/build_mechanism/github_release.rb
+++ b/lib/moonshot/build_mechanism/github_release.rb
@@ -33,6 +33,12 @@ module Moonshot::BuildMechanism
       end
     end
 
+    def build_cli_hook(parser)
+      parser.on('-s', '--skip-ci-status', 'Skips checks on CI jobs', FalseClass) do |value|
+        @skip_ci_status = value
+      end
+    end
+
     def doctor_hook
       super
       @build_mechanism.doctor_hook


### PR DESCRIPTION
Testing Steps:
===

1. cd moonshot/lib/default
2. check --help without GithubRelease plugin
moonshot build --help 
```
moonshot build --help 
Usage: moonshot build VERSION
    -v, --[no-]verbose               Show debug logging
    -n, --environment=NAME           Which environment to operate on.
        --[no-]interactive-logger    Enable or disable fancy logging
```
3. register github plugin by update Moonfile.rb with below content
```
Moonshot.config do |c|
  c.build_mechanism = GithubRelease.new('')
  c.deployment_mechanism = CodeDeploy.new(asg: 'AutoScalingGroup')
end
```
4- check --help again
```
Usage: moonshot build VERSION
    -v, --[no-]verbose               Show debug logging
    -n, --environment=NAME           Which environment to operate on.
        --[no-]interactive-logger    Enable or disable fancy logging
    -s, --skip-ci-status             Skips checks on CI jobs

```