### PR TITLE
CPD-1298 | As a cloud data engineer, I would like to able to skip the SHA status check when building a release.

### DIFF
--- a/lib/moonshot/build_mechanism/github_release.rb
+++ b/lib/moonshot/build_mechanism/github_release.rb
@@ -27,14 +27,8 @@ module Moonshot::BuildMechanism
       @skip_ci_status = skip_ci_status
     end
 
-    def deploy_cli_hook(parser)
-      parser.on('-s', '--skip-ci-status', 'Skips checks on CI jobs', FalseClass) do |value|
-        @skip_ci_status = value
-      end
-    end
-
     def build_cli_hook(parser)
-      parser.on('-s', '--skip-ci-status', 'Skips checks on CI jobs', FalseClass) do |value|
+      parser.on('-s', '--[no-]skip-ci-status', 'Skips checks on CI jobs', TrueClass) do |value|
         @skip_ci_status = value
       end
     end

--- a/spec/moonshot/commands/build_spec.rb
+++ b/spec/moonshot/commands/build_spec.rb
@@ -1,0 +1,19 @@
+describe Moonshot::Commands::Build do
+
+  it 'should not handle --skip-ci-status and build correctly' do
+    cli_dispatcher = Moonshot::CommandLineDispatcher.new('build', subject, {})
+    parser = cli_dispatcher.send(:build_parser, subject)
+    expect { parser.parse(%w(--skip-ci-status)) }.to raise_error(RuntimeError)
+  end
+  
+  it 'should handle --skip-ci-status and build correctly' do
+    Moonshot.config = Moonshot::ControllerConfig.new
+    Moonshot.config do |c|
+      c.build_mechanism = Moonshot::BuildMechanism::GithubRelease.new('')
+    end
+    cli_dispatcher = Moonshot::CommandLineDispatcher.new('build', subject, {})
+    parser = cli_dispatcher.send(:build_parser, subject)
+    expect { parser.parse(%w(--skip-ci-status)) }.to_not raise_error
+  end 
+  
+end


### PR DESCRIPTION

```
moonshot build --help 
Usage: moonshot build VERSION
    -v, --[no-]verbose               Show debug logging
    -n, --environment=NAME           Which environment to operate on.
        --[no-]interactive-logger    Enable or disable fancy logging
    -s, --[no-]skip-ci-status        Skips checks on CI jobs
```

Testing command:
`rspec   spec/moonshot/commands/build_spec.rb`

this PR is tested and working perfect

```
[ ✓ ] [ 0m 22s ] Clone git@github.com:hmagdy/cloud-database-api.git to release-cloud-database-api-1.2.320170831-23703-i8ucvg                 
[ ✓ ] [ 0m 1s ] Checkout 4f43bfbe7edbe6cb950326ad60571a4d85e504f8                                                                            
[ ✓ ] [ 0m 1s ] rsync -a --include='vendor/bundle/***' --include='vendor*/' --exclude='*' /usr/src/aq/repos/cloud-database-api/ ./           
[ ✓ ] [ 24m 29s ] bundle install --deployment -j2                                                                                            
----> bundle exec moonshot build 1.2.3 --skip-ci-status
Skip CI Status flag in build_cli_hook is:
true
I, [2017-08-31T13:29:09.337836 #25897]  INFO -- : git fetch --tags upstream
I, [2017-08-31T13:29:15.051786 #25897]  INFO -- : Success
I, [2017-08-31T13:29:15.072169 #25897]  INFO -- : Validate commit 4f43bfbe7edbe6cb950326ad60571a4d85e504f8.
I, [2017-08-31T13:29:15.109533 #25897]  INFO -- : Success
Ci_statusesin after call check_ci_status is:
I, [2017-08-31T13:29:15.109716 #25897]  INFO -- : Validate `CHANGELOG.md`.
```