### PR TITLE
sort commands

### DIFF
--- a/lib/moonshot/command_line.rb
+++ b/lib/moonshot/command_line.rb
@@ -112,7 +112,7 @@ module Moonshot
         @commands[command_name] = klass
       end
 
-      @commands = @commands.sort_by{ |k,v| k.to_s }.to_h
+      @commands = @commands.sort_by { |k, _v| k.to_s }.to_h
     end
 
     def commandify(klass)

--- a/lib/moonshot/command_line.rb
+++ b/lib/moonshot/command_line.rb
@@ -111,6 +111,8 @@ module Moonshot
         command_name = commandify(klass)
         @commands[command_name] = klass
       end
+
+      @commands = @commands.sort_by{ |k,v| k.to_s }.to_h
     end
 
     def commandify(klass)


### PR DESCRIPTION
Sort the commands by name, so they appear in alphabetical order in the help output.