### PR TITLE
Added ability to push CF template to S3

### DIFF
--- a/lib/moonshot/controller_config.rb
+++ b/lib/moonshot/controller_config.rb
@@ -26,6 +26,7 @@ module Moonshot
     attr_accessor :ssh_command
     attr_accessor :ssh_config
     attr_accessor :ssh_instance
+    attr_accessor :template_s3_bucket
 
     def initialize
       @default_parameter_source = AskUserSource.new

--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -177,15 +177,15 @@ module Moonshot
     end
 
     def upload_template_to_s3
-      raise 'The S3 bucket to store the template in is not configured.' unless @config.template_s3_bucket
+      raise 'The S3 bucket to store the template in is not configured.' unless @config.template_s3_bucket # rubocop:disable LineLength
 
       s3_object_key = "#{@name}-#{File.basename(template.filename)}"
-        s3_client = Aws::S3::Client.new
-        s3_client.put_object(
-          bucket: @config.template_s3_bucket,
-          key: s3_object_key,
-          body: template.body
-        )
+      s3_client = Aws::S3::Client.new
+      s3_client.put_object(
+        bucket: @config.template_s3_bucket,
+        key: s3_object_key,
+        body: template.body
+      )
       template_url = "http://#{@config.template_s3_bucket}.s3.amazonaws.com/#{s3_object_key}"
       puts "The template has been uploaded to #{template_url}"
 

--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -176,14 +176,35 @@ module Moonshot
       raise "Could not describe stack: #{name}"
     end
 
+    def upload_template_to_s3
+      raise 'The S3 bucket to store the template in is not configured.' unless @config.template_s3_bucket
+
+      s3_object_key = "#{@name}-#{File.basename(template.filename)}"
+        s3_client = Aws::S3::Client.new
+        s3_client.put_object(
+          bucket: @config.template_s3_bucket,
+          key: s3_object_key,
+          body: template.body
+        )
+      template_url = "http://#{@config.template_s3_bucket}.s3.amazonaws.com/#{s3_object_key}"
+      puts "The template has been uploaded to #{template_url}"
+
+      template_url
+    end
+
     def create_stack
-      cf_client.create_stack(
+      parameters = {
         stack_name: @name,
-        template_body: template.body,
         capabilities: %w(CAPABILITY_IAM CAPABILITY_NAMED_IAM),
         parameters: @config.parameters.values.map(&:to_cf),
         tags: make_tags
-      )
+      }
+      if @config.template_s3_bucket
+        parameters[:template_url] = upload_template_to_s3
+      else
+        parameters[:template_body] = template.body
+      end
+      cf_client.create_stack(parameters)
     rescue Aws::CloudFormation::Errors::AccessDenied
       raise 'You are not authorized to perform create_stack calls.'
     end
@@ -195,14 +216,20 @@ module Moonshot
         Time.now.utc.to_i.to_s
       ].join('-')
 
-      cf_client.create_change_set(
+      parameters = {
         change_set_name: change_set_name,
         description: "Moonshot update command for application '#{Moonshot.config.app_name}'",
         stack_name: @name,
-        template_body: template.body,
         capabilities:  %w(CAPABILITY_IAM CAPABILITY_NAMED_IAM),
         parameters: @config.parameters.values.map(&:to_cf)
-      )
+      }
+      if @config.template_s3_bucket
+        parameters[:template_url] = upload_template_to_s3
+      else
+        parameters[:template_body] = template.body
+      end
+
+      cf_client.create_change_set(parameters)
 
       change_set_name
     end
@@ -289,7 +316,12 @@ module Moonshot
     end
 
     def doctor_check_template_against_aws
-      cf_client.validate_template(template_body: template.body)
+      if @config.template_s3_bucket
+        parameters[:template_url] = upload_template_to_s3
+      else
+        parameters[:template_body] = template.body
+      end
+      cf_client.validate_template(parameters)
       success('CloudFormation template is valid.')
     rescue => e
       critical('Invalid CloudFormation template!', e.message)

--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -185,7 +185,6 @@ module Moonshot
       template_url = "http://#{@config.template_s3_bucket}.s3.amazonaws.com/#{s3_object_key}"
 
       @ilog.start "Uploading template to #{template_url}" do |s|
-        s3_client = Aws::S3::Client.new
         s3_client.put_object(
           bucket: @config.template_s3_bucket,
           key: s3_object_key,

--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -184,7 +184,7 @@ module Moonshot
       s3_object_key = "#{@name}-#{Time.now.getutc.to_i}-#{File.basename(template.filename)}"
       template_url = "http://#{@config.template_s3_bucket}.s3.amazonaws.com/#{s3_object_key}"
 
-      @ilog.start "Uploading template to #{template_url}" do |s|      
+      @ilog.start "Uploading template to #{template_url}" do |s|
         s3_client = Aws::S3::Client.new
         s3_client.put_object(
           bucket: @config.template_s3_bucket,

--- a/spec/moonshot/stack_spec.rb
+++ b/spec/moonshot/stack_spec.rb
@@ -5,6 +5,7 @@ describe Moonshot::Stack do
   let(:ilog) { Moonshot::InteractiveLoggerProxy.new(log) }
   let(:parent_stacks) { [] }
   let(:cf_client) { instance_double(Aws::CloudFormation::Client) }
+  let(:s3_client) { instance_double(Aws::S3::Client) }
 
   let(:config) { Moonshot::ControllerConfig.new }
   before(:each) do
@@ -14,6 +15,7 @@ describe Moonshot::Stack do
     config.parent_stacks = parent_stacks
 
     allow(Aws::CloudFormation::Client).to receive(:new).and_return(cf_client)
+    allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
   end
 
   subject { described_class.new(config) }
@@ -23,9 +25,9 @@ describe Moonshot::Stack do
     let(:stack_exists) { false }
 
     before(:each) do
-      expect(ilog).to receive(:start).and_yield(step)
+      expect(ilog).to receive(:start).at_least(:once).and_yield(step)
       expect(subject).to receive(:stack_exists?).and_return(stack_exists)
-      expect(step).to receive(:success)
+      expect(step).to receive(:success).at_least(:once)
     end
 
     context 'when the stack creation takes too long' do
@@ -88,9 +90,31 @@ describe Moonshot::Stack do
 
       it 'should call CreateStack, then wait for completion' do
         config.additional_tag = 'ah_stage'
+        expect(s3_client).not_to receive(:put_object)
         expect(cf_client).to receive(:create_stack)
           .with(hash_including(expected_create_stack_options))
         subject.create
+      end
+
+      context 'when template_s3_bucket is set' do
+        before(:each) do
+          config.template_s3_bucket = 'rspec-bucket'
+        end
+
+        let(:expected_put_object_options) do
+          {
+            bucket: config.template_s3_bucket,
+            key: an_instance_of(String),
+            body: an_instance_of(String)
+          }
+        end
+
+        it 'should call put_object' do
+          expect(s3_client).to receive(:put_object)
+            .with(hash_including(expected_put_object_options))
+          expect(cf_client).to receive(:create_stack)
+          subject.create
+        end
       end
     end
   end

--- a/spec/moonshot/stack_spec.rb
+++ b/spec/moonshot/stack_spec.rb
@@ -99,20 +99,28 @@ describe Moonshot::Stack do
       context 'when template_s3_bucket is set' do
         before(:each) do
           config.template_s3_bucket = 'rspec-bucket'
+          allow(Time).to receive(:now).and_return(Time.new('2017-11-07 12:00:00 +0000'))
         end
 
         let(:expected_put_object_options) do
           {
             bucket: config.template_s3_bucket,
-            key: an_instance_of(String),
+            key: 'rspec-app-staging-1483228800-template.yml',
             body: an_instance_of(String)
           }
         end
 
-        it 'should call put_object' do
+        let(:expected_create_stack_options) do
+          {
+            template_url: 'http://rspec-bucket.s3.amazonaws.com/rspec-app-staging-1483228800-template.yml'
+          }
+        end
+
+        it 'should call put_object and create_stack with template_url parameter' do
           expect(s3_client).to receive(:put_object)
             .with(hash_including(expected_put_object_options))
           expect(cf_client).to receive(:create_stack)
+            .with(hash_including(expected_create_stack_options))
           subject.create
         end
       end


### PR DESCRIPTION
I hit the [51,200 bytes size limitation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cloudformation-limits.html) of the template body.
One of the suggested resolutions there is to upload the template to an S3 bucket. This patch makes moonshot to be able to do that.

I added a new configuration option: `template_s3_bucket`. If it's set, moonshot will always upload the local template to that bucket then use its URL in the API calls.