### PR TITLE
Pin require_all version to ~>1.5.0

### DIFF
--- a/moonshot.gemspec
+++ b/moonshot.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency('travis')
   s.add_dependency('vandamme')
   s.add_dependency('pry')
-  s.add_dependency('require_all')
+  s.add_dependency('require_all', '~> 1.5.0')
 
   s.add_development_dependency('rspec')
   s.add_development_dependency('simplecov')


### PR DESCRIPTION
Gem `require_all` 2.0.0 breaks Moonshot with `LoadError` because of a change introduced in https://github.com/jarmo/require_all/pull/24.

```
$ bundle list | grep require_all
  * require_all (2.0.0)
$ bundle exec moonshot new test
bundler: failed to load command: moonshot (/Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/bin/moonshot)
RequireAll::LoadError: Could not require /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/bundler/gems/moonshot-512b19628963/lib/moonshot/artifact_repository/s3_bucket.rb (uninitialized constant Moonshot::ResourcesHelper). Please require the necessary files
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/gems/require_all-2.0.0/lib/require_all.rb:102:in `rescue in block in require_all'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/gems/require_all-2.0.0/lib/require_all.rb:97:in `block in require_all'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/gems/require_all-2.0.0/lib/require_all.rb:96:in `each'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/gems/require_all-2.0.0/lib/require_all.rb:96:in `require_all'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/gems/require_all-2.0.0/lib/require_all.rb:118:in `block in require_rel'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/gems/require_all-2.0.0/lib/require_all.rb:117:in `each'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/gems/require_all-2.0.0/lib/require_all.rb:117:in `require_rel'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/bundler/gems/moonshot-512b19628963/lib/moonshot.rb:28:in `<top (required)>'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/bundler/gems/moonshot-512b19628963/bin/moonshot:2:in `require'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/bundler/gems/moonshot-512b19628963/bin/moonshot:2:in `<top (required)>'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/bin/moonshot:23:in `load'
  /Users/csibar/workspaces/acquia/require_all_fail/vendor/ruby/2.3.0/bin/moonshot:23:in `<top (required)>'
```

Elimination of the aforementioned error can be achieved by requiring all the necessary files in Moonshot codebase, however as a simple and quick workaround we can pin the last working 1.x version prior to 2.0.0, which is 1.5.0 at the time of PR creation.

```
$ bundle list | grep require_all
  * require_all (1.5.0)
$ bundle exec moonshot new test
Your application is configured, the following changes have been made
to your project directory:

  * Created Moonfile.rb, where you can configure your project.
  * Created moonshot/plugins, where you can place custom Ruby code
    to add hooks to core Moonshot actions (create, update, delete, etc.)
  * Created moonshot/cli_extensions, where you can place custom Ruby
    code to add your own project-specific commands to Moonshot.
  * Created moonshot/template.yml, where you can build your
    CloudFormation template.

You will also need to ensure your Amazon account is configured for
CodeDeploy by creating a role that allows deployments.

See: http://moonshot.readthedocs.io/en/latest/mechanisms/deployment/
```

Thanks @janost for letting us know about this issue.
