### PR TITLE
QBG-2 | Update require_all to 2.0

### DIFF
--- a/lib/moonshot/artifact_repository/s3_bucket.rb
+++ b/lib/moonshot/artifact_repository/s3_bucket.rb
@@ -1,3 +1,6 @@
+require_relative '../creds_helper'
+require_relative '../doctor_helper'
+require_relative '../resources_helper'
 # The S3Bucket stores builds in an S3 Bucket.
 #
 # For example:
@@ -6,9 +9,9 @@
 #   self.artifact_repository = S3Bucket.new('my-application-builds')
 # end
 class Moonshot::ArtifactRepository::S3Bucket
-  include Moonshot::ResourcesHelper
   include Moonshot::CredsHelper
   include Moonshot::DoctorHelper
+  include Moonshot::ResourcesHelper
 
   attr_reader :bucket_name
 

--- a/lib/moonshot/commands/create.rb
+++ b/lib/moonshot/commands/create.rb
@@ -1,3 +1,7 @@
+require_relative 'parameter_arguments'
+require_relative 'show_all_events_option'
+require_relative 'parent_stack_option'
+
 module Moonshot
   module Commands
     class Create < Moonshot::Command

--- a/lib/moonshot/commands/ssh.rb
+++ b/lib/moonshot/commands/ssh.rb
@@ -1,3 +1,4 @@
+require_relative '../ssh_command'
 module Moonshot
   module Commands
     class Ssh < Moonshot::SSHCommand

--- a/lib/moonshot/json_stack_template.rb
+++ b/lib/moonshot/json_stack_template.rb
@@ -1,4 +1,5 @@
 require 'json'
+require_relative 'stack_template'
 
 module Moonshot
   # Handles JSON formatted AWS template files.

--- a/moonshot.gemspec
+++ b/moonshot.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency('travis')
   s.add_dependency('vandamme')
   s.add_dependency('pry')
-  s.add_dependency('require_all', '~> 1.5.0')
+  s.add_dependency('require_all', '~> 2.0.0')
 
   s.add_development_dependency('rspec')
   s.add_development_dependency('simplecov')


### PR DESCRIPTION
Require_All raises instead of retrying in the event of a NameError forcing out of order requires to be force loaded.

Details Here: https://github.com/jarmo/require_all/blob/master/CHANGES.md


There may be a better way but this functions.