### PR TITLE
Fix: Changeset update executed if dry-run

### DIFF
--- a/lib/moonshot/controller.rb
+++ b/lib/moonshot/controller.rb
@@ -112,7 +112,7 @@ module Moonshot
 
       run_hook(:deploy, :pre_update)
       stack.update(dry_run: dry_run, force: force)
-      run_hook(:deploy, :post_update)
+      run_hook(:deploy, :post_update) unless dry_run
       run_plugins(:post_update)
     end
 

--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -46,9 +46,7 @@ module Moonshot
 
       return change_set.delete if dry_run
 
-      unless force
-        change_set.confirm? || raise('ChangeSet rejected!')
-      end
+      !force && change_set.confirm? || raise('ChangeSet rejected!')
 
       execute_change_set(change_set)
     end

--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -42,10 +42,11 @@ module Moonshot
       wait_for_change_set(change_set)
       return unless change_set.valid?
 
-      if dry_run
-        change_set.display_changes
-      elsif !force
-        change_set.display_changes
+      change_set.display_changes
+
+      return change_set.delete if dry_run
+
+      unless force
         change_set.confirm? || raise('ChangeSet rejected!')
       end
 


### PR DESCRIPTION
I don't know what's the desired logic with hooks on `--dry-run`.

It was a bit painful when I met #225 on one of my personal projects.