### PR TITLE
Expose build CLI options for version proxy mechanisms.

### DIFF
--- a/lib/moonshot/build_mechanism/github_release.rb
+++ b/lib/moonshot/build_mechanism/github_release.rb
@@ -31,6 +31,8 @@ module Moonshot::BuildMechanism
       parser.on('-s', '--[no-]skip-ci-status', 'Skips checks on CI jobs', TrueClass) do |value|
         @skip_ci_status = value
       end
+
+      parser
     end
 
     def doctor_hook

--- a/lib/moonshot/build_mechanism/version_proxy.rb
+++ b/lib/moonshot/build_mechanism/version_proxy.rb
@@ -37,6 +37,17 @@ class Moonshot::BuildMechanism::VersionProxy
     active(version).post_build_hook(version)
   end
 
+  def build_cli_hook(parser)
+    # Expose any command line arguments provided by the build mechanisms. We
+    # don't know the version at this point, so we can't call the hook on only
+    # the one we're going to use, which may result in options being exposed that
+    # are only applicable for one of the build mechanisms.
+    parser = @release.build_cli_hook(parser) if @release.respond_to?(:build_cli_hook)
+    parser = @dev.build_cli_hook(parser) if @dev.respond_to?(:build_cli_hook)
+
+    parser
+  end
+
   private
 
   def active(version)


### PR DESCRIPTION
This resolves an issue where the build command fails when passing a command line argument provided by one of the build mechanisms configured in the version proxy mechanism. It does however present an issue that I've documented in the code here.