### PR TITLE
Fixed CloudFormation template check in 'doctor'.

### DIFF
--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -320,12 +320,13 @@ module Moonshot
     end
 
     def doctor_check_template_against_aws
+      validate_params = {}
       if @config.template_s3_bucket
-        parameters[:template_url] = upload_template_to_s3
+        validate_params[:template_url] = upload_template_to_s3
       else
-        parameters[:template_body] = template.body
+        validate_params[:template_body] = template.body
       end
-      cf_client.validate_template(parameters)
+      cf_client.validate_template(validate_params)
       success('CloudFormation template is valid.')
     rescue => e
       critical('Invalid CloudFormation template!', e.message)


### PR DESCRIPTION
Doctor fails on master HEAD because it sends all parameters of a stack to the template validation call. `parameters` on line 324 is actually a function call (see line 83) which returns the parameters of a stack. The template url/body was added to this hash and sent to AWS on line 328 in `validate_template`. Since that call expects only the url or the body (https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/CloudFormation/Client.html#validate_template-instance_method), it failed like this:

```
11:51 master $ bundle exec moonshot doctor
Stack
  ✓ CloudFormation template found at 'xxx.json'.
  ✗ Invalid CloudFormation template!
      parameter validator found 33 errors:
        - unexpected value at params["xxx"]
        - unexpected value at params["xxx"]
        - unexpected value at params["xxx"]
...
```

This proposed change fixes the issue. cc @glennpratt @jamesiarmes 