### PR TITLE
CPD-183: Added pre-check to plugin

### DIFF
--- a/docs/plugins/rotate_asg_instances.md
+++ b/docs/plugins/rotate_asg_instances.md
@@ -9,12 +9,9 @@ After all outdated instances are shutdown successfully, it terminates them and r
 It allows gracefully shutting down each instance instead of terminating them and killing all the running processes.
 
 ## Configuration
-The plugin uses the ssh username specified in the `MOONSHOT_SSH_USER` or the `LOGNAME` environment variable for logging into the ASG instances to shutdown. The value should be the username with which you have the access to the instances. For example:
-```ruby
-export MOONSHOT_SSH_USER=abhishek.rana
-```
+The plugin uses config.ssh_config.ssh_user value for logging into the ASG instances to shutdown. The value should be the username with which you have the access to the instances.
 
-The plugin needs no additional configuration parameters:
+The plugin accepts additional configuration from config.ssh_config.ssh_options for ssh.
 
 ## Example
 ```ruby

--- a/lib/moonshot/ssh_command_builder.rb
+++ b/lib/moonshot/ssh_command_builder.rb
@@ -12,6 +12,7 @@ module Moonshot
 
     def build(command = nil)
       cmd = ['ssh', '-t']
+      cmd << @config.ssh_options if @config.ssh_options
       cmd << "-i #{@config.ssh_identity_file}" if @config.ssh_identity_file
       cmd << "-l #{@config.ssh_user}" if @config.ssh_user
       cmd << instance_ip

--- a/lib/moonshot/ssh_config.rb
+++ b/lib/moonshot/ssh_config.rb
@@ -2,10 +2,12 @@ module Moonshot
   class SSHConfig
     attr_accessor :ssh_identity_file
     attr_accessor :ssh_user
+    attr_accessor :ssh_options
 
     def initialize
       @ssh_identity_file = ENV['MOONSHOT_SSH_KEY_FILE']
       @ssh_user = ENV['MOONSHOT_SSH_USER']
+      @ssh_options = ENV['MOONSHOT_SSH_OPTIONS']
     end
   end
 end

--- a/lib/moonshot/ssh_fork_executor.rb
+++ b/lib/moonshot/ssh_fork_executor.rb
@@ -3,18 +3,18 @@ require 'open3'
 module Moonshot
   # Run an SSH command via fork/exec.
   class SSHForkExecutor
-    Result = Struct.new(:output, :exitstatus)
+    Result = Struct.new(:output, :error, :exitstatus)
 
     def run(cmd)
-      output = StringIO.new
-
+      output = error = StringIO.new
       exit_status = nil
-      Open3.popen3(cmd) do |_, stdout, _, wt|
+      Open3.popen3(cmd) do |_, stdout, stderr, wt|
+        error << stderr.read until stderr.eof?
         output << stdout.read until stdout.eof?
         exit_status = wt.value.exitstatus
       end
 
-      Result.new(output.string.chomp, exit_status)
+      Result.new(output.string.chomp, error.string.chomp, exit_status)
     end
   end
 end

--- a/lib/plugins/rotate_asg_instances.rb
+++ b/lib/plugins/rotate_asg_instances.rb
@@ -1,16 +1,39 @@
 # frozen_string_literal: true
 
 require 'aws-sdk'
-require_relative 'rotate_asg_instances/asg'
 
 module Moonshot
   module Plugins
     # Rotate ASG instances after update.
     class RotateAsgInstances
+      include DoctorHelper
+
+      def doctor(resources)
+        @resources = resources
+        run_all_checks
+      end
+
+      def pre_update(resources)
+        @resources = resources
+        asg.verify_ssh
+      end
+
       def post_update(resources)
-        asg = ASG.new(resources)
-        asg.rotate_asg_instances
-        asg.teardown_outdated_instances
+        @resources = resources
+        asg.perform_rotation
+      end
+
+      private
+
+      def asg
+        Moonshot::RotateAsgInstances::ASG.new(@resources)
+      end
+
+      def doctor_check_ssh
+        asg.verify_ssh
+        success('Successfully opened SSH connection to an instance.')
+      rescue Moonshot::RotateAsgInstances::SSHValidationError
+        critical('SSH connection test failed, check your SSH settings')
       end
     end
   end

--- a/lib/plugins/rotate_asg_instances/asg.rb
+++ b/lib/plugins/rotate_asg_instances/asg.rb
@@ -1,238 +1,246 @@
-require 'moonshot/ssh_fork_executor'
-
 module Moonshot
-  class ASG # rubocop:disable Metrics/ClassLength
-    include Moonshot::CredsHelper
+  module RotateAsgInstances
+    class ASG # rubocop:disable Metrics/ClassLength
+      include Moonshot::CredsHelper
 
-    def initialize(resources)
-      @resources = resources
-      @ilog = @resources.ilog
-      @ssh_user = ENV['MOONSHOT_SSH_USER'] || ENV['LOGNAME']
-    end
-
-    def asg
-      @asg ||=
-        Aws::AutoScaling::AutoScalingGroup.new(name: physical_resource_id)
-    end
-
-    def rotate_asg_instances
-      @ilog.start_threaded('Rotating ASG instances...') do |step|
-        @step = step
-        @volumes_to_delete = outdated_volumes(outdated_instances)
-        @shutdown_instances = cycle_instances(outdated_instances)
-        @step.success('ASG instances rotated successfully!')
+      def initialize(resources)
+        @resources = resources
+        @ssh = Moonshot::RotateAsgInstances::SSH.new
+        @ilog = @resources.ilog
       end
-    end
 
-    def teardown_outdated_instances
-      @ilog.start_threaded('Tearing down outdated instances...') do |step|
-        @step = step
-        terminate_instances(@shutdown_instances)
-        reap_volumes(@volumes_to_delete)
-        @step.success('Outdated instances removed successfully!')
+      def perform_rotation
+        rotate_asg_instances
+        teardown_outdated_instances
       end
-    end
 
-    def physical_resource_id
-      @resources.controller.stack
-                .resources_of_type('AWS::AutoScaling::AutoScalingGroup')
-                .first.physical_resource_id
-    end
+      def verify_ssh
+        @ssh.test_ssh_connection(first_instance_id)
+      end
 
-    def outdated_instances
-      @outdated_instances ||=
+      private
+
+      def asg
+        @asg ||=
+          Aws::AutoScaling::AutoScalingGroup.new(name: physical_resource_id)
+      end
+
+      def first_instance_id
+        SSHTargetSelector.new(
+          @resources.controller.stack,
+          asg_name: Moonshot.config.ssh_auto_scaling_group_name
+        ).choose!
+      end
+
+      def rotate_asg_instances
+        @ilog.start_threaded('Rotating ASG instances...') do |step|
+          @step = step
+          outdated = identify_outdated_instances
+          @volumes_to_delete = outdated_volumes(outdated)
+          @shutdown_instances = cycle_instances(outdated)
+          @step.success('ASG instances rotated successfully!')
+        end
+      end
+
+      def teardown_outdated_instances
+        @ilog.start_threaded('Tearing down outdated instances...') do |step|
+          @step = step
+          terminate_instances(@shutdown_instances)
+          reap_volumes(@volumes_to_delete)
+          @step.success('Outdated instances removed successfully!')
+        end
+      end
+
+      def identify_outdated_instances
         asg.instances.reject do |i|
           i.launch_configuration_name == asg.launch_configuration_name
         end
-    end
+      end
 
-    private
+      def physical_resource_id
+        @resources.controller.stack
+                  .resources_of_type('AWS::AutoScaling::AutoScalingGroup')
+                  .first.physical_resource_id
+      end
 
-    def outdated_volumes(outdated_instances)
-      volumes = []
-      outdated_instances.each do |i|
-        begin
-          inst = Aws::EC2::Instance.new(id: i.id)
-          volumes << inst.block_device_mappings.first.ebs.volume_id
-        rescue StandardError => e
-          # We're catching all errors here, because failing to reap a volume
-          # is not a critical error, will not cause issues with the update.
-          @step.failure('Failed to get volumes for instance '\
-                    "#{i.instance_id}: #{e.message}")
+      def outdated_volumes(outdated_instances)
+        volumes = []
+        outdated_instances.each do |i|
+          begin
+            inst = Aws::EC2::Instance.new(id: i.id)
+            volumes << inst.block_device_mappings.first.ebs.volume_id
+          rescue StandardError => e
+            # We're catching all errors here, because failing to reap a volume
+            # is not a critical error, will not cause issues with the update.
+            @step.failure('Failed to get volumes for instance '\
+                      "#{i.instance_id}: #{e.message}")
+          end
+        end
+        volumes
+      end
+
+      # Cycle the instances in the ASG.
+      #
+      # Each instance will be detached one at a time, waiting for the new instance
+      # to be ready before stopping the worker and terminating the instance.
+      #
+      # @param instances [Array] (outdated instances)
+      #   List of instances to cycle. Defaults to all instances with outdated
+      #   launch configurations.
+      # @return [Array] (array of Aws::AutoScaling::Instance)
+      #   List of shutdown instances.
+      def cycle_instances(outdated_instances)
+        shutdown_instances = []
+
+        if outdated_instances.empty?
+          @step.success('No instances cycled!')
+          return []
+        end
+
+        @step.success("Cycling #{outdated_instances.size} " \
+                      "of #{asg.instances.size} instances in " \
+                      "#{physical_resource_id}...")
+
+        # Iterate over the instances in the stack, detaching and terminating each
+        # one.
+        outdated_instances.each do |i|
+          next if %w(Terminating Terminated).include?(i.lifecycle_state)
+
+          wait_for_instance(i)
+          detach_instance(i)
+
+          @step.success("Shutting down #{i.instance_id}")
+          shutdown_instance(i.instance_id)
+          shutdown_instances << i
+        end
+
+        @step.success('All instances cycled.')
+
+        shutdown_instances
+      end
+
+      # Waits for an instance to reach a ready state.
+      #
+      # @param instance [Aws::AutoScaling::Instance] Auto scaling instance to wait
+      #   for.
+      def wait_for_instance(instance, state = 'InService')
+        instance.wait_until(max_attempts: 60, delay: 10) do |i|
+          i.lifecycle_state == state
         end
       end
-      volumes
-    end
 
-    # Cycle the instances in the ASG.
-    #
-    # Each instance will be detached one at a time, waiting for the new instance
-    # to be ready before stopping the worker and terminating the instance.
-    #
-    # @param instances [Array] (outdated instances)
-    #   List of instances to cycle. Defaults to all instances with outdated
-    #   launch configurations.
-    # @return [Array] (array of Aws::AutoScaling::Instance)
-    #   List of shutdown instances.
-    def cycle_instances(outdated_instances)
-      shutdown_instances = []
+      # Detach an instance from its ASG. Re-attach if failed.
+      #
+      # @param instance [Aws::AutoScaling::Instance] Instance to detach.
+      def detach_instance(instance)
+        @step.success("Detaching instance: #{instance.instance_id}")
 
-      if outdated_instances.empty?
-        @step.success('No instances cycled!')
-        return []
+        # If the ASG can't be brought up to capacity, re-attach the instance.
+        begin
+          instance.detach(should_decrement_desired_capacity: false)
+          @step.success('- Waiting for the AutoScaling '\
+                       'Group to be up to capacity')
+          wait_for_capacity
+        rescue StandardError => e
+          @step.failure("Error bringing the ASG up to capacity: #{e.message}")
+          @step.failure("Attaching instance: #{instance.instance_id}")
+          reattach_instance(instance)
+          raise e
+        end
       end
 
-      @step.success("Cycling #{outdated_instances.size} " \
-                    "of #{asg.instances.size} instances in " \
-                    "#{physical_resource_id}...")
-
-      # Iterate over the instances in the stack, detaching and terminating each
-      # one.
-      outdated_instances.each do |i|
-        next if %w(Terminating Terminated).include?(i.lifecycle_state)
-
-        wait_for_instance(i)
-        detach_instance(i)
-
-        @step.success("Shutting down #{i.instance_id}")
-        shutdown_instance(i.instance_id)
-        shutdown_instances << i
-      end
-
-      @step.success('All instances cycled.')
-
-      shutdown_instances
-    end
-
-    # Waits for an instance to reach a ready state.
-    #
-    # @param instance [Aws::AutoScaling::Instance] Auto scaling instance to wait
-    #   for.
-    def wait_for_instance(instance, state = 'InService')
-      instance.wait_until(max_attempts: 60, delay: 10) do |i|
-        i.lifecycle_state == state
-      end
-    end
-
-    # Detach an instance from its ASG. Re-attach if failed.
-    #
-    # @param instance [Aws::AutoScaling::Instance] Instance to detach.
-    def detach_instance(instance)
-      @step.success("Detaching instance: #{instance.instance_id}")
-
-      # If the ASG can't be brought up to capacity, re-attach the instance.
-      begin
-        instance.detach(should_decrement_desired_capacity: false)
-        @step.success('- Waiting for the AutoScaling '\
-                     'Group to be up to capacity')
-        wait_for_capacity
-      rescue StandardError => e
-        @step.failure("Error bringing the ASG up to capacity: #{e.message}")
-        @step.failure("Attaching instance: #{instance.instance_id}")
-        reattach_instance(instance)
-        raise e
-      end
-    end
-
-    # Re-attach an instance to its ASG.
-    #
-    # @param instance [Aws::AutoScaling::Instance] Instance to re-attach.
-    def reattach_instance(instance)
-      instance.load
-      return unless instance.data.nil? \
-        || %w(Detached Detaching).include?(instance.lifecycle_state)
-
-      until instance.data.nil? || instance.lifecycle_state == 'Detached'
-        sleep 10
+      # Re-attach an instance to its ASG.
+      #
+      # @param instance [Aws::AutoScaling::Instance] Instance to re-attach.
+      def reattach_instance(instance)
         instance.load
-      end
-      instance.attach
-    end
+        return unless instance.data.nil? \
+          || %w(Detached Detaching).include?(instance.lifecycle_state)
 
-    # Terminate instances.
-    #
-    # @param instances [Array] (instances for termination)
-    #   List of instances to terminate. Defaults to all instances with outdated
-    #   launch configurations.
-    def terminate_instances(outdated_instances)
-      if outdated_instances.any?
-        @step.continue(
-          "Terminating #{outdated_instances.size} outdated instances..."
-        )
-      end
-      outdated_instances.each do |asg_instance|
-        instance = Aws::EC2::Instance.new(asg_instance.instance_id)
-        begin
+        until instance.data.nil? || instance.lifecycle_state == 'Detached'
+          sleep 10
           instance.load
-        rescue Aws::EC2::Errors::InvalidInstanceIDNotFound
-          next
+        end
+        instance.attach
+      end
+
+      # Terminate instances.
+      #
+      # @param instances [Array] (instances for termination)
+      #   List of instances to terminate. Defaults to all instances with outdated
+      #   launch configurations.
+      def terminate_instances(shutdown_instances)
+        if shutdown_instances.any?
+          @step.continue(
+            "Terminating #{shutdown_instances.size} outdated instances..."
+          )
+        end
+        shutdown_instances.each do |asg_instance|
+          instance = Aws::EC2::Instance.new(asg_instance.instance_id)
+          begin
+            instance.load
+          rescue Aws::EC2::Errors::InvalidInstanceIDNotFound
+            next
+          end
+
+          next unless %w(stopping stopped).include?(instance.state.name)
+
+          instance.wait_until_stopped
+
+          @step.continue("Terminating #{instance.instance_id}")
+          instance.terminate
+        end
+      end
+
+      def reap_volumes(volumes)
+        volumes.each do |volume_id|
+          begin
+            @step.continue("Deleting volume: #{volume_id}")
+            ec2_client(region: ENV['AWS_REGION'])
+              .delete_volume(volume_id: volume_id)
+          rescue StandardError => e
+            # We're catching all errors here, because failing to reap a volume
+            # is not a critical error, will not cause issues with the release.
+            @step.failure("Failed to delete volume #{volume_id}: #{e.message}")
+          end
+        end
+      end
+
+      # Waits for the ASG to reach the desired capacity.
+      def wait_for_capacity
+        @step.continue(
+          'Replacing outdated instances with new instances for the AutoScaling Group...'
+        )
+        # While we wait for the asg to reach capacity, report instance statuses
+        # to the user.
+        before_wait = proc do
+          instances = []
+          asg.reload.instances.each do |i|
+            instances << " #{i.instance_id} (#{i.lifecycle_state})"
+          end
+
+          @step.continue("Instances: #{instances.join(', ')}")
         end
 
-        next unless %w(stopping stopped).include?(instance.state.name)
+        asg.reload.wait_until(before_wait: before_wait, max_attempts: 60,
+                              delay: 30) do |a|
+          instances_up = a.instances.select do |i|
+            i.lifecycle_state == 'InService'
+          end
+          instances_up.length == a.desired_capacity
+        end
+        @step.success('AutoScaling Group up to capacity!')
+      end
 
+      # Shuts down an instance, waiting for the instance to stop processing requests
+      # first. We do this so that services will be stopped properly.
+      #
+      # @param id [String] ID of the instance to terminate.
+      def shutdown_instance(id)
+        instance = Aws::EC2::Instance.new(id: id)
+        @ssh.exec('sudo shutdown -h now', id)
         instance.wait_until_stopped
-
-        @step.continue("Terminating #{instance.instance_id}")
-        instance.terminate
       end
-    end
-
-    def reap_volumes(volumes)
-      volumes.each do |volume_id|
-        begin
-          @step.continue("Deleting volume: #{volume_id}")
-          ec2_client(region: ENV['AWS_REGION'])
-            .delete_volume(volume_id: volume_id)
-        rescue StandardError => e
-          # We're catching all errors here, because failing to reap a volume
-          # is not a critical error, will not cause issues with the release.
-          @step.failure("Failed to delete volume #{volume_id}: #{e.message}")
-        end
-      end
-    end
-
-    # Waits for the ASG to reach the desired capacity.
-    def wait_for_capacity
-      @step.continue(
-        'Replacing outdated instances with new instances for the AutoScaling Group...'
-      )
-      # While we wait for the asg to reach capacity, report instance statuses
-      # to the user.
-      before_wait = proc do
-        instances = []
-        asg.reload.instances.each do |i|
-          instances << " #{i.instance_id} (#{i.lifecycle_state})"
-        end
-
-        @step.continue("Instances: #{instances.join(', ')}")
-      end
-
-      asg.reload.wait_until(before_wait: before_wait, max_attempts: 60,
-                            delay: 30) do |a|
-        instances_up = a.instances.select do |i|
-          i.lifecycle_state == 'InService'
-        end
-        instances_up.length == a.desired_capacity
-      end
-      @step.success('AutoScaling Group up to capacity!')
-    end
-
-    # Shuts down an instance, waiting for the instance to stop processing requests
-    # first. We do this so that services will be stopped properly.
-    #
-    # @param id [String] ID of the instance to terminate.
-    def shutdown_instance(id)
-      instance = Aws::EC2::Instance.new(id: id)
-      options = [
-        'UserKnownHostsFile=/dev/null',
-        'StrictHostKeyChecking=no'
-      ]
-      remote = "#{@ssh_user}@#{instance.public_dns_name}"
-      cmd = "'sudo shutdown -h now'"
-      remote_cmd = "ssh -o #{options.join(' -o ')} #{remote} #{cmd}"
-      SSHForkExecutor.new.run(remote_cmd)
-
-      instance.wait_until_stopped
     end
   end
 end

--- a/lib/plugins/rotate_asg_instances/ssh.rb
+++ b/lib/plugins/rotate_asg_instances/ssh.rb
@@ -1,0 +1,34 @@
+module Moonshot
+  module RotateAsgInstances
+    class SSHValidationError < StandardError
+      def initialize(response)
+        super("SSH failed. exit status: #{response.exitstatus} " \
+              "output: #{response.output} error: #{response.error}")
+      end
+    end
+
+    class SSH
+      # As per the standard it is raising correctly but still giving an error.
+      def test_ssh_connection(instance_id)
+        Retriable.retriable(base_interval: 5, tries: 3) do
+          response = exec('/bin/true', instance_id)
+          # rubocop:disable Style/RaiseArgs
+          raise SSHValidationError.new(response) unless
+            response.exitstatus.zero?
+        end
+      end
+
+      def exec(command, instance_id)
+        fe = SSHForkExecutor.new
+        fe.run(build_command(command, instance_id))
+      end
+
+      private
+
+      def build_command(command, instance_id)
+        cb = SSHCommandBuilder.new(Moonshot.config.ssh_config, instance_id)
+        cb.build(command).cmd
+      end
+    end
+  end
+end

--- a/spec/moonshot/plugins/rotate_asg_instances/ssh_spec.rb
+++ b/spec/moonshot/plugins/rotate_asg_instances/ssh_spec.rb
@@ -1,0 +1,52 @@
+describe Moonshot::RotateAsgInstances::SSH do
+  let(:instance_id) { 'i-585e91dc' }
+  let(:command) { '/bin/true' }
+  let(:result) { Struct.new(:output, :error, :exitstatus) }
+  let(:successful_response) { result.new('Output', 'No Failure', 0) }
+  let(:validation_error) do
+    Moonshot::RotateAsgInstances::SSHValidationError.new(
+      result.new('Output', 'Failure', 255)
+    )
+  end
+  let(:moonshot_config) { Moonshot::ControllerConfig.new }
+  let(:controller) do
+    instance_double('Moonshot::Controller',
+                    config: moonshot_config,
+                    stack: instance_double(
+                      Moonshot::Stack,
+                      name: 'test_name',
+                      parameters: {}
+                    )
+    )
+  end
+  let(:resources) do
+    instance_double(
+      Moonshot::Resources,
+      ilog: instance_double(Moonshot::InteractiveLoggerProxy),
+      controller: controller
+    )
+  end
+
+  let(:config) { resources.controller.config }
+
+  subject { described_class.new }
+
+  describe '#test_ssh_connection' do
+    it 'raise error if #test_ssh_connection fails' do
+      allow(subject).to receive(:test_ssh_connection).with(instance_id).and_raise(validation_error)
+      expect { subject.test_ssh_connection(instance_id) }.to raise_error(validation_error)
+    end
+
+    it 'does not raise error if ssh is successful' do
+      allow(subject).to receive(:test_ssh_connection).with(instance_id).and_return(successful_response)
+      expect { subject.test_ssh_connection(instance_id) }.not_to raise_error
+    end
+  end
+
+  describe '#exec' do
+    it 'executes the command given' do
+      allow(subject).to receive(:exec).with(command, instance_id).and_return(successful_response)
+      expect(subject.exec(command, instance_id)).to eql(successful_response)
+    end
+  end
+end

--- a/spec/moonshot/plugins/rotate_asg_instances_spec.rb
+++ b/spec/moonshot/plugins/rotate_asg_instances_spec.rb
@@ -1,0 +1,49 @@
+describe Moonshot::Plugins::RotateAsgInstances do
+  let(:instance_id) { 'i-585e91dc' }
+  let(:result) { Struct.new(:output, :error, :exitstatus) }
+  let(:validation_error) do
+    Moonshot::RotateAsgInstances::SSHValidationError.new(
+      result.new('Output', 'Failure', 255)
+    )
+  end
+  let(:successful_response) { result.new('Output', 'No Failure', 0) }
+  let(:moonshot_config) { Moonshot::ControllerConfig.new }
+  let(:controller) do
+    instance_double('Moonshot::Controller',
+                    config: moonshot_config,
+                    stack: instance_double(
+                      Moonshot::Stack,
+                      name: 'test_name',
+                      parameters: {}
+                    )
+    )
+  end
+  let(:resources) do
+    instance_double(
+      Moonshot::Resources,
+      ilog: instance_double(Moonshot::InteractiveLoggerProxy),
+      controller: controller
+    )
+  end
+
+  subject { described_class.new }
+
+  let(:ssh) { Moonshot::RotateAsgInstances::SSH }
+
+  before(:each) do
+    subject.instance_variable_set(:@resources, resources)
+    expect_any_instance_of(Moonshot::SSHTargetSelector).to receive(:choose!).and_return(instance_id)
+  end
+
+  describe '#doctor' do
+    it 'raises error if check is not passed' do
+      allow_any_instance_of(ssh).to receive(:test_ssh_connection).with(instance_id).and_raise(validation_error)
+      expect{ subject.send(:doctor_check_ssh) }.to raise_error(Moonshot::DoctorCritical)
+    end
+
+    it 'does not raise error when check is passed' do
+      allow_any_instance_of(ssh).to receive(:test_ssh_connection).with(instance_id).and_return(successful_response)
+      expect{ subject.send(:doctor_check_ssh) }.not_to raise_error
+    end
+  end
+end

--- a/spec/moonshot/ssh_spec.rb
+++ b/spec/moonshot/ssh_spec.rb
@@ -6,11 +6,14 @@ describe 'Moonshot SSH features' do
     c.ssh_config.ssh_user = 'joeuser'
     c.ssh_config.ssh_identity_file = '/Users/joeuser/.ssh/thegoods.key'
     c.ssh_command = 'cat /etc/passwd'
-
     Moonshot::Controller.new(c)
   end
 
   describe 'Moonshot::Controller#ssh' do
+    before(:each) do
+      ENV.delete('MOONSHOT_SSH_OPTIONS')
+    end
+
     context 'normally' do
       it 'should execute an ssh command with proper parameters' do
         ts = instance_double(Moonshot::SSHTargetSelector)


### PR DESCRIPTION
Change: minor
Purpose: feature

**Release test**: [#511](https://cloud-data.jenkins.r53.ahdev.co/job/rls-test-dev/511) ✅
**System test**: [#1081](https://cloud-data.jenkins.r53.ahdev.co/job/sys-test-dev/1081) ✅ 
**Manual Review**: [Review document](https://confluence.acquia.com/x/vwnPBg)

### Related PRs:
- [cloud-database-api](https://github.com/acquia/cloud-database-api/pull/1739)
- [cloud-database-worker](https://github.com/acquia/cloud-database-worker/pull/1020)


Added a pre-check for verifying the plugin can work before attempting to rotate AutoScalingGroup instances.