### PR TITLE
CPD-6009: Rescue and continue if the instance is already detached

### DIFF
--- a/lib/plugins/rotate_asg_instances/asg.rb
+++ b/lib/plugins/rotate_asg_instances/asg.rb
@@ -141,6 +141,9 @@ module Moonshot
           @step.success('- Waiting for the AutoScaling '\
                        'Group to be up to capacity')
           wait_for_capacity
+        rescue Aws::AutoScaling::Errors::ValidationError => e
+            raise e unless e.message.include?("is not part of Auto Scaling group")
+            wait_for_capacity
         rescue StandardError => e
           @step.failure("Error bringing the ASG up to capacity: #{e.message}")
           @step.failure("Attaching instance: #{instance.instance_id}")


### PR DESCRIPTION
Change: minor
Purpose: maintenance

Manual review steps:

1. Get a worker stack and make sure the min instances is 2 or more else update it.
2. Make a trivial update to launch config, updating the ami id is a good example.
3. Issue stack update using moonshot
`moonshot update -n STACK_NAME`
4. while the first instance is being rotated by the rotation plugin, detach the other instance.
5. As the plugin moves forward and tries to rotate the other instance it raises error.
6. Update the moonshot gem to use code from this PR.
7. Repeat steps 1 through 4. It should not raise an error