### PR TITLE
CPD-7518: Add tags option to create command.

### DIFF
--- a/lib/moonshot/commands/create.rb
+++ b/lib/moonshot/commands/create.rb
@@ -33,6 +33,15 @@ module Moonshot
         parser.on('--template-file=FILE', 'Override the path to the CloudFormation template.') do |v|
           Moonshot.config.template_file = v
         end
+
+        parser.on('--tag KEY=VALUE', '-TKEY=VALUE', 'Specify stack tags on the command line') do |v|
+          data = v.split('=', 2)
+          unless data.size == 2
+            raise "Invalid tag format '#{v}', expected KEY=VALUE (e.g. MyStackTag=12)"
+          end
+
+          Moonshot.config.extra_tags << { key: data[0], value: data[1] }
+        end
       end
 
       def execute

--- a/lib/moonshot/controller_config.rb
+++ b/lib/moonshot/controller_config.rb
@@ -12,6 +12,7 @@ module Moonshot
     attr_accessor :deployment_mechanism
     attr_accessor :dev_build_name_proc
     attr_accessor :environment_name
+    attr_accessor :extra_tags
     attr_accessor :interactive
     attr_accessor :interactive_logger
     attr_accessor :parameter_overrides
@@ -43,6 +44,7 @@ module Moonshot
       @project_root             = Dir.pwd
       @show_all_stack_events    = false
       @ssh_config               = SSHConfig.new
+      @extra_tags               = []
 
       @dev_build_name_proc = lambda do |c|
         ['dev', c.app_name, c.environment_name, Time.now.to_i].join('/')

--- a/lib/moonshot/stack.rb
+++ b/lib/moonshot/stack.rb
@@ -300,7 +300,7 @@ module Moonshot
         default_tags << { key: @config.additional_tag, value: @name }
       end
 
-      default_tags
+      default_tags + @config.extra_tags
     end
 
     def format_event(event)

--- a/spec/moonshot/commands/create_spec.rb
+++ b/spec/moonshot/commands/create_spec.rb
@@ -16,6 +16,22 @@ describe Moonshot::Commands::Create do
     end
   end
 
+  extra_tags = {
+    %w(-T Key=Value -T OtherKey=OtherValue) =>
+      [{ key: 'Key', value: 'Value' }, { key: 'OtherKey', value: 'OtherValue' }],
+    %w(-TKey=ValueWith=Equals) => [{ key: 'Key', value: 'ValueWith=Equals' }],
+    %w(--tag Key=Value --tag OtherKey=OtherValue) =>
+      [{ key: 'Key', value: 'Value' }, { key: 'OtherKey', value: 'OtherValue' }]
+  }
+
+  extra_tags.each do |input, expected|
+    it "Should process #{input} correctly" do
+      op = subject.parser
+      op.parse(input)
+      expect(Moonshot.config.extra_tags).to match(expected)
+    end
+  end
+
   it 'should handle version and deploy correctly' do
     op = subject.parser
     op.parse(%w(--version 1.2.3 --no-deploy -P Key=Value))

--- a/spec/moonshot/stack_spec.rb
+++ b/spec/moonshot/stack_spec.rb
@@ -132,6 +132,31 @@ describe Moonshot::Stack do
           subject.create
         end
       end
+
+      context 'when has extra tags' do
+        let(:expected_create_stack_options) do
+          {
+            tags: [
+              { key: 'moonshot_application', value: 'rspec-app' },
+              { key: 'moonshot_environment', value: 'staging' },
+              { key: 'tag1', value: 'A' },
+              { key: 'tag2', value: 'B' }
+            ]
+          }
+        end
+
+        before do
+          config.extra_tags << { key: 'tag1', value: 'A' }
+          config.extra_tags << { key: 'tag2', value: 'B' }
+        end
+
+        it 'should call CreateStack, then wait for completion' do
+          expect(s3_client).not_to receive(:put_object)
+          expect(cf_client).to receive(:create_stack)
+            .with(hash_including(expected_create_stack_options))
+          subject.create
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Using custom CF template
```
{
  "Resources": {
    "HelloBucket": {
      "Type": "AWS::S3::Bucket"
    }
  }
}
```


Create options
```
➜ cloud-database-api ruby-2.7.3 (CPD-7518-fix) ✗ bundle exec moonshot help create                                              <aws:cloudservicesdev>
Using the Central Model for authentication
Version 2 of the Ruby SDK will enter maintenance mode as of November 20, 2020. To continue receiving service updates and new features, please upgrade to Version 3. More information can be found here: https://aws.amazon.com/blogs/developer/deprecation-schedule-for-aws-sdk-for-ruby-v2/
Using the Central Model for authentication
Usage: moonshot create [options]
    -v, --[no-]verbose               Show debug logging
    -n, --environment=NAME           Which environment to operate on.
        --[no-]interactive-logger    Enable or disable fancy logging
    -t, --token-provider=PROVIDER
        --[no-]interactive           Use interactive prompts for gathering missing configuration.
    -a, --answer-fileFILE            Load Stack Parameters from a YAML file
    -P, --parameterKEY=VALUE         Specify Stack Parameter on the command line
        --[no-]show-all-events       Show all stack events during update
    -p, --parent=PARENT_STACK        Parent stack to import parameters from
        --parents a,b,c              List of parent stacks to import parameters from
    -d, --[no-]deploy                Choose if code should be deployed immediately after the stack is created
        --version VERSION_NAME       Version for initial deployment. If unset, a new development build is created from the local directory
        --template-file=FILE         Override the path to the CloudFormation template.
    -T, --tagsKEY=VALUE              Specify stack tags on the command line
```


Passing tags to create command
```
➜ cloud-database-api ruby-2.7.3 (CPD-7518-fix) ✗ bundle exec moonshot create -ncdb-api-dev-toshio-test --template-file ./cloud_formation/test.json -Tstory=CPD-7518 -Tstory-type=bug
Using the Central Model for authentication
Version 2 of the Ruby SDK will enter maintenance mode as of November 20, 2020. To continue receiving service updates and new features, please upgrade to Version 3. More information can be found here: https://aws.amazon.com/blogs/developer/deprecation-schedule-for-aws-sdk-for-ruby-v2/
Using the Central Model for authentication
[ ✓ ] [ 0m 2s ] Created CloudFormation Stack cdb-api-cdb-api-dev-toshio-test.                                                                         
[ ✓ ] [ 0m 36s ] CloudFormation Stack cdb-api-cdb-api-dev-toshio-test successfully created.  
```

Stack tags
```
➜ cloud-database-api ruby-2.7.3 (CPD-7518-fix) ✗ aws cloudformation describe-stacks --stack-name cdb-api-cdb-api-dev-toshio-test --query Stacks[].Tags 
[
    [
        {
            "Key": "moonshot_application",
            "Value": "cdb-api"
        },
        {
            "Key": "story-type",
            "Value": "bug"
        },
        {
            "Key": "moonshot_environment",
            "Value": "cdb-api-dev-toshio-test"
        },
        {
            "Key": "story",
            "Value": "CPD-7518"
        }
    ]
]
```

Bucket tags
```
➜ cloud-database-api ruby-2.7.3 (CPD-7518-fix) ✗ aws s3api get-bucket-tagging --bucket cdb-api-cdb-api-dev-toshio-test-hellobucket-17hano27ri6xv
Enter MFA code for arn:aws:iam::484203365684:mfa/marcio.toshio: 
{
    "TagSet": [
        {
            "Key": "aws:cloudformation:stack-name",
            "Value": "cdb-api-cdb-api-dev-toshio-test"
        },
        {
            "Key": "aws:cloudformation:stack-id",
            "Value": "arn:aws:cloudformation:us-east-1:672327909798:stack/cdb-api-cdb-api-dev-toshio-test/52e0e700-53cf-11ed-9b68-0aa2623b7b2f"
        },
        {
            "Key": "moonshot_application",
            "Value": "cdb-api"
        },
        {
            "Key": "story-type",
            "Value": "bug"
        },
        {
            "Key": "moonshot_environment",
            "Value": "cdb-api-dev-toshio-test"
        },
        {
            "Key": "aws:cloudformation:logical-id",
            "Value": "HelloBucket"
        },
        {
            "Key": "story",
            "Value": "CPD-7518"
        }
    ]
}
```