### PR TITLE
CPD-8183: use correct command to validate hub authorization

### DIFF
--- a/lib/moonshot/build_mechanism/github_release.rb
+++ b/lib/moonshot/build_mechanism/github_release.rb
@@ -227,7 +227,7 @@ module Moonshot::BuildMechanism
     end
 
     def doctor_check_hub_auth
-      sh_out('hub ci-status 0.0.0')
+      sh_out('hub ci-status')
     rescue => e
       critical "`hub` failed, install hub and authorize it.\n#{e.message}"
     else

--- a/lib/moonshot/build_mechanism/github_release.rb
+++ b/lib/moonshot/build_mechanism/github_release.rb
@@ -227,7 +227,7 @@ module Moonshot::BuildMechanism
     end
 
     def doctor_check_hub_auth
-      sh_out('hub ci-status')
+      sh_out('hub api user')
     rescue => e
       critical "`hub` failed, install hub and authorize it.\n#{e.message}"
     else

--- a/spec/moonshot/build_mechanism/github_release_spec.rb
+++ b/spec/moonshot/build_mechanism/github_release_spec.rb
@@ -57,7 +57,7 @@ module Moonshot # rubocop:disable ModuleLength
       describe '#doctor_check_hub_auth' do
         it 'should succeed with 0 exit status.' do
           expect(subject).to receive(:sh_out)
-            .with('hub ci-status 0.0.0')
+            .with('hub ci-status')
           expect(subject).to receive(:success)
             .with('`hub` installed and authorized.')
           subject.send(:doctor_check_hub_auth)
@@ -65,7 +65,7 @@ module Moonshot # rubocop:disable ModuleLength
 
         it 'should critical with non-zero exit status.' do
           expect(subject).to receive(:sh_out)
-            .with('hub ci-status 0.0.0')
+            .with('hub ci-status')
             .and_raise(RuntimeError, 'oops')
           expect(subject).to receive(:critical)
             .with("`hub` failed, install hub and authorize it.\noops")

--- a/spec/moonshot/build_mechanism/github_release_spec.rb
+++ b/spec/moonshot/build_mechanism/github_release_spec.rb
@@ -57,7 +57,7 @@ module Moonshot # rubocop:disable ModuleLength
       describe '#doctor_check_hub_auth' do
         it 'should succeed with 0 exit status.' do
           expect(subject).to receive(:sh_out)
-            .with('hub ci-status')
+            .with('hub api user')
           expect(subject).to receive(:success)
             .with('`hub` installed and authorized.')
           subject.send(:doctor_check_hub_auth)
@@ -65,7 +65,7 @@ module Moonshot # rubocop:disable ModuleLength
 
         it 'should critical with non-zero exit status.' do
           expect(subject).to receive(:sh_out)
-            .with('hub ci-status')
+            .with('hub api user')
             .and_raise(RuntimeError, 'oops')
           expect(subject).to receive(:critical)
             .with("`hub` failed, install hub and authorize it.\noops")


### PR DESCRIPTION
**Motivation**
(https://backlog.acquia.com/browse/CPD-8183)


**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->
