### PR TITLE
PC-17819 | Fix HAPI Errors related to Loadbalancing

### DIFF
--- a/lib/moonshot/tools/asg_rollout/asg.rb
+++ b/lib/moonshot/tools/asg_rollout/asg.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'aws-sdk-elasticloadbalancing'
+require 'aws-sdk-autoscaling'
 
 module Moonshot
   module Tools

--- a/lib/moonshot/tools/asg_rollout/asg.rb
+++ b/lib/moonshot/tools/asg_rollout/asg.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'aws-sdk-elasticloadbalancing'
+require 'aws-sdk-autoscaling'
+
 module Moonshot
   module Tools
     class ASGRollout

--- a/lib/moonshot/tools/asg_rollout/asg.rb
+++ b/lib/moonshot/tools/asg_rollout/asg.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'aws-sdk-elasticloadbalancing'
-require 'aws-sdk-autoscaling'
-
 module Moonshot
   module Tools
     class ASGRollout

--- a/lib/moonshot/tools/asg_rollout/asg.rb
+++ b/lib/moonshot/tools/asg_rollout/asg.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'aws-sdk-elasticloadbalancing'
+
 module Moonshot
   module Tools
     class ASGRollout

--- a/moonshot.gemspec
+++ b/moonshot.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency('aws-sdk-autoscaling', '~> 1.5')
   s.add_dependency('aws-sdk-cloudformation', '~> 1.4')
   s.add_dependency('aws-sdk-codedeploy', '~> 1.5')
+  s.add_dependency('aws-sdk-elasticloadbalancing', '~> 1.3')
   s.add_dependency('aws-sdk-ec2', '~> 1.34')
   s.add_dependency('aws-sdk-iam', '~> 1.4')
   s.add_dependency('aws-sdk-s3', '~> 1.12')


### PR DESCRIPTION
**Motivation**
```
[cloudservicesdev|hosting-dev:prasan4] ~/git/hosting-api$ hosting-api rollout-launch-configuration --skip-hooks
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Using the Central Model for authentication
[ ✓ ] [ 0m 4s ] Increased MaxSize/DesiredCapacity by 1.                                                                                                                                     
[ ✓ ] [ 0m 12s ] A wild i-091b8aa01f8b901ff appears!                                                                                                                                        
[ | ] [ 0m 0s ] Waiting for i-091b8aa01f8b901ff to be InService...#<Thread:0x0000000109dfdf18 /Users/nalaka/git/hosting-api/vendor/bundle/ruby/3.1.0/gems/interactive-logger-0.1.3/lib/interactive-logger.rb:39 run> terminated with exception (report_on_exception is true):
/Users/nalaka/git/hosting-api/vendor/bundle/ruby/3.1.0/bundler/gems/moonshot-7b5be09cd891/lib/moonshot/tools/asg_rollout/asg.rb:122:in `rescue in elb_instance_state': uninitialized constant Aws::ElasticLoadBalancing (NameError)

        rescue Aws::ElasticLoadBalancing::Errors::InvalidInstance
                  ^^^^^^^^^^^^^^^^^^^^^^
	from /Users/nalaka/git/hosting-api/vendor/bundle/ruby/3.1.0/bundler/gems/moonshot-7b5be09cd891/lib/moonshot/tools/asg_rollout/asg.rb:112:in `elb_instance_state'
	from /Users/nalaka/git/hosting-api/vendor/bundle/ruby/3.1.0/bundler/gems/moonshot-7b5be09cd891/lib/moonshot/tools/asg_rollout/asg.rb:94:in `instance_health'
	from /Users/nalaka/git/hosting-api/vendor/bundle/ruby/3.1.0/bundler/gems/moonshot-7b5be09cd891/lib/moonshot/tools/asg_rollout.rb:73:in `block (2 levels) in wait_for_in_service'
	from /Users/nalaka/git/hosting-api/vendor/bundle/ruby/3.1.0/bundler/gems/moonshot-7b5be09cd891/lib/moonshot/tools/asg_rollout.rb:72:in `loop'
	from /Users/nalaka/git/hosting-api/vendor/bundle/ruby/3.1.0/bundler/gems/moonshot-7b5be09cd891/lib/moonshot/tools/asg_rollout.rb:72:in `block in wait_for_in_service'
	from /Users/nalaka/git/hosting-api/vendor/bundle/ruby/3.1.0/gems/interactive-logger-0.1.3/lib/interactive-logger.rb:40:in `block in start_threaded'
/Users/nalaka/git/hosting-api/vendor/bundle/ruby/3.1.0/bundler/gems/moonshot-7b5be09cd891/lib/moonshot/tools/asg_rollout/asg.rb:132:in `loadbalancing': uninitialized constant Aws::ElasticLoadBalancing (NameError)

          @loadbalancing ||= Aws::ElasticLoadBalancing::Client.new
```

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
- Update hapi gemfile with the test branches
```
  gem 'cloud-moonshot-plugins', git: 'git@github.com:nalakafernando/cloud-moonshot-plugins.git', branch: 'PC-17819-2'
  gem 'moonshot', git: 'git@github.com:nalakafernando/moonshot.git', branch: 'PC-17819-2'
```
- Issue a bundle update 
- Run hapi rollout launch configs
```
[cloudservicesdev|hosting-dev:prasan4] ~/git/hosting-api$ hosting-api rollout-launch-configuration --skip-hooks
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Using the Central Model for authentication
[ ✓ ] [ 0m 4s ] Increased MaxSize/DesiredCapacity by 1.                                                                                                                                     
[ ✓ ] [ 0m 8s ] A wild i-00fa763f813145402 appears!                                                                                                                                         
[ ✓ ] [ 2m 37s ] Instance i-00fa763f813145402 is ASG:InService/ELB:InService!                                                                                                               
[ ✓ ] [ 0m 1s ] Restored MaxSize/DesiredCapacity values to normal!                                                                                                                          
Saving session...
...saving history...truncating history files...
...completed.
[cloudservicesdev|hosting-dev:prasan4] ~/git/hosting-api$ 
```

