### PR TITLE
CPD-8525 | When in US regions, the api and worker should use AWS FIPS endpoints where available

### DIFF
--- a/lib/moonshot.rb
+++ b/lib/moonshot.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'English'
-require 'aws-sdk'
+
+require 'aws-sdk-cloudformation'
+require 'aws-sdk-codedeploy'
+require 'aws-sdk-ec2'
+require 'aws-sdk-iam'
+require 'aws-sdk-autoscaling'
+require 'aws-sdk-s3'
 
 require 'logger'
 require 'thor'

--- a/lib/moonshot/change_set.rb
+++ b/lib/moonshot/change_set.rb
@@ -76,35 +76,13 @@ module Moonshot
       retry
     end
 
-    # NOTE: At the time of this patch, AWS-SDK native Waiters do not
-    # have support for ChangeSets. Once they add this, we can make
-    # this code much better.
-    # Still no support for this waiter, but it's planned.
-    # https://github.com/aws/aws-sdk-ruby/issues/1388
     def wait_for_change_set
-      wait_seconds = Moonshot.config.changeset_wait_time || 90
-      start = Time.now.to_i
+      @cf_client.wait_until(:change_set_create_complete,
+                            stack_name: @stack_name,
+                            change_set_name: @name)
 
-      loop do
-        resp = @cf_client.describe_change_set(
-          change_set_name: @name,
-          stack_name: @stack_name
-        )
-
-        if %w[CREATE_COMPLETE FAILED].include?(resp.status)
-          @change_set = resp
-          return
-        end
-
-        if Time.now.to_i > start + wait_seconds
-          raise "ChangeSet did not complete creation within #{wait_seconds} seconds!"
-        end
-
-        sleep 5 # http://bit.ly/1qY1ZXJ
-        # Wait 5 seconds because other waiters seem to wait at least 5 seconds
-        # before repeating requests.
-        # See: https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/apis/cloudformation/2010-05-15/waiters-2.json#L5
-      end
+      @change_set = @cf_client.describe_change_set(stack_name: @stack_name,
+      change_set_name: @name)
     end
   end
 end

--- a/moonshot.gemspec
+++ b/moonshot.gemspec
@@ -15,7 +15,13 @@ Gem::Specification.new do |s|
   s.executables = ['moonshot']
   s.homepage    = 'https://github.com/acquia/moonshot'
 
-  s.add_dependency('aws-sdk', '~> 2.0', '>= 2.2.0')
+  s.add_dependency('aws-sdk-cloudformation', '~> 1.4')
+  s.add_dependency('aws-sdk-codedeploy', '~> 1.5')
+  s.add_dependency('aws-sdk-ec2', '~> 1.34')
+  s.add_dependency('aws-sdk-iam', '~> 1.4')
+  s.add_dependency('aws-sdk-autoscaling', '~> 1.5')
+  s.add_dependency('aws-sdk-s3', '~> 1.12')
+  
   s.required_ruby_version = '>= 3.1.2'
 
   s.add_dependency('activesupport', '= 6.1.7.1')


### PR DESCRIPTION
**Motivation**
FIPS endpoint is only supported from aws-sdk v3 onwards so we have to upgrade the gem from v2 to v3. 

**Proposed changes**
Updates aws-sdk gem to v3

**Alternatives considered**
N/A

**Testing steps**
N/A
