### PR TITLE
PC-26333 | Update activesupport gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /coverage
 site/
 sample/gems
+.idea

--- a/moonshot.gemspec
+++ b/moonshot.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('aws-sdk-iam', '~> 1.4')
   s.add_dependency('aws-sdk-s3', '~> 1.12')
 
-  s.add_dependency('activesupport')
+  s.add_dependency('activesupport', '~> 8.1.1')
   s.add_dependency('colorize')
   s.add_dependency('faraday', '~> 1.0')
   s.add_dependency('faraday-rack', '~> 1.0.0')


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->

```
[cloudservicesdev|hosting-dev:pc-team-35] ~/Acquia/Repos/fields/limit-monitor$ bundle show moonshot
/Users/hirantha/.rvm/gems/ruby-3.3.4/bundler/gems/moonshot-26d80a011b15
[cloudservicesdev|hosting-dev:pc-team-35] ~/Acquia/Repos/fields/limit-monitor$ 
[cloudservicesdev|hosting-dev:pc-team-35] ~/Acquia/Repos/fields/limit-monitor$ bundle info moonshot
  * moonshot (3.0.5 26d80a0)
  Summary: A library and CLI tool for launching services into AWS
  Homepage: https://github.com/acquia/moonshot
  Path: /Users/hirantha/.rvm/gems/ruby-3.3.4/bundler/gems/moonshot-26d80a011b15
  Reverse Dependencies: 
    cloud-moonshot-plugins (3.0.2) depends on moonshot (>= 0)
[cloudservicesdev|hosting-dev:pc-team-35] ~/Acquia/Repos/fields/limit-monitor$


[cloudservicesdev|hosting-dev:pc-team-35] ~/Acquia/Repos/fields/limit-monitor$ bundle exec moonshot status
Using the Central Model for authentication
CloudFormation Stack limit-monitor-dev-hirantha does NOT exist.
[cloudservicesdev|hosting-dev:pc-team-35] ~/Acquia/Repos/fields/limit-monitor$ 

[cloudservicesdev|hosting-dev:pc-team-35] ~/Acquia/Repos/fields/limit-monitor$ in-account cloudservicesdev bundle exec moonshot create
Using the Central Model for authentication
(TopicEmail) E-Mail address to subscribe to alerts []: 
Using default value.
(AccountList) Quote Encapsulated, Comma Delimited List of Account Numbers to Scan for Limits ["672327909798"]: 
Using default value.
(SNSTopicName) Name of the SNS Topic for E-Mail Alerts [LimitCheckSNS]: 
Using default value.
(CheckRoleName) Name of IAM Role created to check limits [LimitCheckRole]: 
Using default value.
(SendAnonymousData) Send anonymous data to AWS [No]: 
Using default value.
[ ✓ ] [ 0m 8s ] Created CloudFormation Stack limit-monitor-dev-hirantha.                                                                                                                                        
--> CREATE_FAILED SNSTopic Resource handler returned message: "Invalid parameter: Endpoint (Service: Sns, Status Code: 400, Request ID: 7251a92e-53f5-5782-8e17-c8f7c906187f) (SDK Attempt Count: 1)" (RequestToken: ce76d541-1808-eb7c-a74c-be908e47cce8, HandlerErrorCode: GeneralServiceException)
--> CREATE_FAILED ConfigRole Resource creation cancelled                                                                                                                                                        
[ ✗ ] [ 2m 18s ] CloudFormation Stack limit-monitor-dev-hirantha failed to update.                                                                                                                              
Stack creation failed! (at /Users/hirantha/.rvm/gems/ruby-3.3.4/bundler/gems/moonshot-26d80a011b15/lib/moonshot/controller.rb:65:in `create')
[cloudservicesdev|hosting-dev:pc-team-35] ~/Acquia/Repos/fields/limit-monitor$ 
```
